### PR TITLE
content: add confirmation bias (FR + EN)

### DIFF
--- a/src/content/biases/confirmation/en.md
+++ b/src/content/biases/confirmation/en.md
@@ -1,0 +1,57 @@
+---
+slug: "confirmation"
+title: "Confirmation bias"
+originalName: "Confirmation bias"
+family: "not-enough-meaning"
+tags: ["judgment", "belief", "information"]
+difficulty: "easy"
+sources:
+  wikipedia: "https://en.wikipedia.org/wiki/Confirmation_bias"
+  papers:
+    - title: "The case for motivated reasoning — Kunda, 1990"
+      url: "https://doi.org/10.1037/0033-2909.108.3.480"
+  videos:
+    - title: "Confirmation Bias — Veritasium"
+      url: "https://www.youtube.com/watch?v=vKA4w2O61Xo"
+      lang: "en"
+relatedBiases: ["anchoring"]
+situation:
+  type: "choice"
+  scenario: "You are convinced a new diet works. You come across an article criticizing it. What do you do?"
+  choices:
+    - label: "I close the article — it's probably funded by the food industry"
+      bias: true
+    - label: "I read the full article to understand its arguments"
+      bias: false
+  reveal: "Dismissing information without reading it because it contradicts your beliefs is a classic example of confirmation bias."
+quiz:
+  questions:
+    - question: "Confirmation bias makes us..."
+      choices:
+        - "Seek information that confirms what we already believe"
+        - "Question all of our opinions"
+        - "Ignore all forms of information"
+      correct: 0
+      explanation: "We naturally look for evidence that reinforces our existing beliefs and dismiss evidence that contradicts them."
+    - question: "Where is confirmation bias particularly dangerous?"
+      choices:
+        - "In scientific research"
+        - "In cooking"
+        - "In sports"
+      correct: 0
+      explanation: "In science, confirmation bias can lead researchers to only retain results that support their hypothesis and ignore the rest."
+---
+
+## Definition
+
+Confirmation bias is the tendency to favor information that confirms our beliefs and to ignore information that contradicts them.
+
+## Mechanism
+
+Our brain is not an impartial judge. When we hold an opinion, we unconsciously seek evidence that supports it. We interpret ambiguous information in our favor and give less credit to sources that contradict us.
+
+## Examples
+
+- On social media, algorithms reinforce this bias by showing us content aligned with our views.
+- A recruiter convinced a candidate is good will interpret their answers more favorably.
+- In politics, we watch media that reinforce our positions and avoid outlets that challenge them.

--- a/src/content/biases/confirmation/fr.md
+++ b/src/content/biases/confirmation/fr.md
@@ -1,0 +1,57 @@
+---
+slug: "de-confirmation"
+title: "Biais de confirmation"
+originalName: "Confirmation bias"
+family: "not-enough-meaning"
+tags: ["jugement", "croyance", "information"]
+difficulty: "easy"
+sources:
+  wikipedia: "https://fr.wikipedia.org/wiki/Biais_de_confirmation"
+  papers:
+    - title: "Biais de confirmation — Albert Moukheiber, 2019 (Votre cerveau vous joue des tours)"
+      url: "https://www.odilejacob.fr/catalogue/sciences/neurosciences/votre-cerveau-vous-joue-des-tours_9782738145826.php"
+  videos:
+    - title: "Le biais de confirmation — Hygiène Mentale"
+      url: "https://www.youtube.com/watch?v=6cFKyIvNMg4"
+      lang: "fr"
+relatedBiases: ["anchoring"]
+situation:
+  type: "choice"
+  scenario: "Vous etes convaincu qu'un nouveau regime alimentaire est efficace. Vous tombez sur un article qui le critique. Que faites-vous ?"
+  choices:
+    - label: "Je ferme l'article, il doit etre finance par l'industrie"
+      bias: true
+    - label: "Je lis l'article en entier pour comprendre ses arguments"
+      bias: false
+  reveal: "Rejeter une information sans la lire parce qu'elle contredit vos croyances est un exemple classique du biais de confirmation."
+quiz:
+  questions:
+    - question: "Le biais de confirmation nous pousse a..."
+      choices:
+        - "Chercher des informations qui confirment ce qu'on croit deja"
+        - "Remettre en question toutes nos opinions"
+        - "Ignorer toute forme d'information"
+      correct: 0
+      explanation: "Nous cherchons naturellement des preuves qui renforcent nos croyances existantes, et ignorons celles qui les contredisent."
+    - question: "Ou le biais de confirmation est-il particulierement dangereux ?"
+      choices:
+        - "Dans la recherche scientifique"
+        - "En cuisine"
+        - "En sport"
+      correct: 0
+      explanation: "En science, le biais de confirmation peut conduire a ne retenir que les resultats qui soutiennent une hypothese et ignorer les autres."
+---
+
+## Definition
+
+Le biais de confirmation est la tendance a privilegier les informations qui confirment nos croyances et a ignorer celles qui les contredisent.
+
+## Mecanisme
+
+Notre cerveau n'est pas un juge impartial. Quand nous avons une opinion, nous cherchons inconsciemment des preuves qui la soutiennent. Nous interpretons les informations ambigues en notre faveur et accordons moins de credit aux sources qui nous contredisent.
+
+## Exemples
+
+- Sur les reseaux sociaux, les algorithmes renforcent ce biais en nous montrant du contenu aligné avec nos opinions.
+- Un recruteur convaincu qu'un candidat est bon interpretera ses reponses de maniere plus favorable.
+- En politique, nous regardons les medias qui confortent nos positions et evitons les autres.


### PR DESCRIPTION
## Summary

- Add confirmation bias content in French and English
- Family: "not-enough-meaning" (populates a second family on the homepage)
- Difficulty: easy
- Includes interactive situation (diet article scenario) and 2-question quiz
- Fix: remove leftover console.log from biases.ts

## Note

FR slug is `de-confirmation` (not `confirmation`) to avoid collision with the EN entry — Astro's glob loader uses frontmatter slugs as entry IDs.