### PR TITLE
refactor: centralize locale slug redirects in middleware

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -66,6 +66,28 @@ export const getLocaleFromAcceptLanguage = (header: string | null): Locale => {
 	return match ?? DEFAULT_LOCALE;
 };
 
+/** All slug keys used for localized routes, typed against actual i18n keys. */
+const SLUG_KEYS: readonly TranslationKey[] = [
+	"slug.leaderboard",
+	"slug.about",
+	"slug.profile",
+	"slug.bias",
+];
+
+/**
+ * Reverse map from any localized slug to its canonical key and owning locale.
+ * E.g. "classement" → { key: "slug.leaderboard", locale: "fr" }
+ * Built once at module load, supports any number of locales.
+ */
+export const slugToLocaleMap = new Map<string, { key: TranslationKey; locale: Locale }>();
+
+for (const locale of SUPPORTED_LOCALES) {
+	for (const key of SLUG_KEYS) {
+		const slug = t(locale, key);
+		slugToLocaleMap.set(slug, { key, locale });
+	}
+}
+
 /**
  * Validates a route `lang` param and returns the locale.
  * Returns `null` if the param is missing or not a supported locale,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,18 @@
 import { defineMiddleware } from "astro:middleware";
-import { getLocaleFromAcceptLanguage, getLocaleFromUrl, isLocale } from "@/i18n/i18n";
+import {
+	getLocaleFromAcceptLanguage,
+	getLocaleFromUrl,
+	isLocale,
+	slugToLocaleMap,
+	t,
+} from "@/i18n/i18n";
 
 /**
- * Populates `Astro.locals` with locale and current path.
- * Redirects to the browser's preferred locale if the URL lang segment is invalid.
+ * Populates `Astro.locals` with locale, current path, and registration status.
+ * Handles two types of redirects:
+ * 1. Invalid locale prefix → redirect to browser-preferred locale
+ * 2. Wrong locale slug → redirect to the correct slug for the current locale
+ *    (e.g. /fr/leaderboard → /fr/classement, /en/biais/ancrage → /en/bias/ancrage)
  */
 export const onRequest = defineMiddleware((context, next) => {
 	const { url, request } = context;
@@ -26,7 +35,26 @@ export const onRequest = defineMiddleware((context, next) => {
 		return context.redirect(`/${fallback}/`);
 	}
 
-	context.locals.locale = langSegment;
+	const locale = langSegment;
+	context.locals.locale = locale;
 	context.locals.currentPath = url.pathname;
+
+	// Redirect localized slugs that don't match the current locale.
+	// E.g. /fr/leaderboard → /fr/classement, /en/biais/ancrage → /en/bias/ancrage
+	const segments = url.pathname.split("/").filter(Boolean);
+	const pageSlug = segments[1];
+
+	if (pageSlug) {
+		const match = slugToLocaleMap.get(pageSlug);
+
+		if (match && match.locale !== locale) {
+			// This slug belongs to another locale — redirect to the correct one
+			const correctSlug = t(locale, match.key);
+			const rest = segments.slice(2).join("/");
+			const redirectPath = rest ? `/${locale}/${correctSlug}/${rest}` : `/${locale}/${correctSlug}`;
+			return context.redirect(redirectPath);
+		}
+	}
+
 	return next();
 });

--- a/src/pages/[lang]/a-propos.astro
+++ b/src/pages/[lang]/a-propos.astro
@@ -1,17 +1,10 @@
 ---
-/**
- * About page (French route: /fr/a-propos).
- * Redirects English users to /en/about.
- */
+/** About page (French route: /fr/a-propos). */
 import AboutPage from "@/components/AboutPage.astro";
 import { t } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 
 const { locale } = Astro.locals;
-
-if (locale === "en") {
-	return Astro.redirect("/en/about");
-}
 
 Astro.locals.altLangHrefs = { en: "/en/about" };
 

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -1,17 +1,10 @@
 ---
-/**
- * About page (English route: /en/about).
- * Redirects French users to /fr/a-propos.
- */
+/** About page (English route: /en/about). */
 import AboutPage from "@/components/AboutPage.astro";
 import { t } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 
 const { locale } = Astro.locals;
-
-if (locale === "fr") {
-	return Astro.redirect("/fr/a-propos");
-}
 
 Astro.locals.altLangHrefs = { fr: "/fr/a-propos" };
 

--- a/src/pages/[lang]/biais/[slug].astro
+++ b/src/pages/[lang]/biais/[slug].astro
@@ -7,18 +7,11 @@ import { getBiasesForLocale } from "@/lib/biases";
 /**
  * French bias page — renders a single cognitive bias entry.
  * URL pattern: /:lang/biais/:slug (e.g. /fr/biais/ancrage).
- * Redirects EN users to /en/bias/:slug.
- * Also computes alternate-language URLs so the Header language switcher
- * can link to the same bias in another locale.
+ * Locale redirects are handled by the middleware.
  */
 
 const { locale } = Astro.locals;
 const { slug } = Astro.params;
-
-// Redirect EN users to the /en/bias/ route
-if (locale === "en") {
-	return Astro.redirect(`/en/bias/${slug}`);
-}
 
 // Fetch all biases, then filter to current locale and find by slug
 const { all: allBiases, localized: biases } = await getBiasesForLocale(locale);

--- a/src/pages/[lang]/bias/[slug].astro
+++ b/src/pages/[lang]/bias/[slug].astro
@@ -7,18 +7,11 @@ import { getBiasesForLocale } from "@/lib/biases";
 /**
  * English bias page — renders a single cognitive bias entry.
  * URL pattern: /:lang/bias/:slug (e.g. /en/bias/anchoring).
- * Redirects FR users to /fr/biais/:slug.
- * Also computes alternate-language URLs so the Header language switcher
- * can link to the same bias in another locale.
+ * Locale redirects are handled by the middleware.
  */
 
 const { locale } = Astro.locals;
 const { slug } = Astro.params;
-
-// Redirect FR users to the /fr/biais/ route
-if (locale === "fr") {
-	return Astro.redirect(`/fr/biais/${slug}`);
-}
 
 // Fetch all biases, then filter to current locale and find by slug
 const { all: allBiases, localized: biases } = await getBiasesForLocale(locale);

--- a/src/pages/[lang]/classement.astro
+++ b/src/pages/[lang]/classement.astro
@@ -1,17 +1,10 @@
 ---
-/**
- * Leaderboard page (French route: /fr/classement).
- * Redirects English users to /en/leaderboard.
- */
+/** Leaderboard page (French route: /fr/classement). */
 import Leaderboard from "@/components/Leaderboard.svelte";
 import { t } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 
 const { locale } = Astro.locals;
-
-if (locale === "en") {
-	return Astro.redirect("/en/leaderboard");
-}
 
 Astro.locals.altLangHrefs = { en: "/en/leaderboard" };
 

--- a/src/pages/[lang]/leaderboard.astro
+++ b/src/pages/[lang]/leaderboard.astro
@@ -1,17 +1,10 @@
 ---
-/**
- * Leaderboard page (English route: /en/leaderboard).
- * Redirects French users to /fr/classement.
- */
+/** Leaderboard page (English route: /en/leaderboard). */
 import LeaderboardComponent from "@/components/Leaderboard.svelte";
 import { t } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 
 const { locale } = Astro.locals;
-
-if (locale === "fr") {
-	return Astro.redirect("/fr/classement");
-}
 
 Astro.locals.altLangHrefs = { fr: "/fr/classement" };
 

--- a/src/pages/[lang]/profil.astro
+++ b/src/pages/[lang]/profil.astro
@@ -7,10 +7,6 @@ import { getProfileLabels } from "@/lib/labels";
 
 const { locale } = Astro.locals;
 
-if (locale === "en") {
-	return Astro.redirect("/en/profile");
-}
-
 const { localized: biases } = await getBiasesForLocale(locale);
 const title = `${t(locale, "profile.title")} — ${t(locale, "site.title")}`;
 

--- a/src/pages/[lang]/profile.astro
+++ b/src/pages/[lang]/profile.astro
@@ -7,10 +7,6 @@ import { getProfileLabels } from "@/lib/labels";
 
 const { locale } = Astro.locals;
 
-if (locale === "fr") {
-	return Astro.redirect("/fr/profil");
-}
-
 const { localized: biases } = await getBiasesForLocale(locale);
 const title = `${t(locale, "profile.title")} — ${t(locale, "site.title")}`;
 


### PR DESCRIPTION
## Summary

- Build a reverse slug→locale map from i18n `slug.*` keys at module load in `i18n.ts`
- Middleware intercepts wrong-locale slugs and redirects generically (e.g. `/fr/leaderboard` → `/fr/classement`, `/en/biais/ancrage` → `/en/bias/ancrage`)
- Supports dynamic routes: preserves path segments after the slug prefix
- Supports any number of locales — no hardcoded FR/EN pairs, ready for ES
- Remove per-page redirect logic from all 8 route files

## Test plan

- [x] 58 unit tests passing
- [ ] Navigate to `/fr/leaderboard` → redirects to `/fr/classement`
- [ ] Navigate to `/en/classement` → redirects to `/en/leaderboard`
- [ ] Navigate to `/en/biais/ancrage` → redirects to `/en/bias/ancrage`
- [ ] Navigate to `/fr/bias/anchoring` → redirects to `/fr/biais/anchoring`
- [ ] Navigate to `/fr/profile` → redirects to `/fr/profil`
- [ ] Normal navigation (correct slugs) works without redirect
- [ ] Language switcher still works on all pages