### PR TITLE
content: add 6 new cognitive biases (FR + EN)

### DIFF
--- a/src/content/biases/availability/en.md
+++ b/src/content/biases/availability/en.md
@@ -1,0 +1,53 @@
+---
+slug: "availability"
+title: "Availability bias"
+originalName: "Availability bias"
+family: "too-much-information"
+tags: ["memory", "probability", "media"]
+difficulty: "medium"
+sources:
+  wikipedia: "https://en.wikipedia.org/wiki/Availability_heuristic"
+  papers:
+    - title: "Availability: A Heuristic for Judging Frequency and Probability — Tversky & Kahneman, 1973"
+      url: "https://doi.org/10.1016/0010-0285(73)90033-9"
+relatedBiases: ["anchoring", "survivorship"]
+situation:
+  type: "choice"
+  scenario: "After watching several news reports about plane crashes, you need to take a flight. How do you feel?"
+  choices:
+    - label: "Flying is dangerous, I'd rather drive"
+      bias: true
+    - label: "News reports don't change the statistics — flying is still the safest transport"
+      bias: false
+  reveal: "The news reports made plane crashes very 'available' in your memory, making you overestimate their frequency. In reality, driving is far riskier."
+quiz:
+  questions:
+    - question: "Availability bias makes us..."
+      choices:
+        - "Overestimate the probability of events that are easy to recall"
+        - "Forget recent events"
+        - "Underestimate all risks"
+      correct: 0
+      explanation: "The easier an event is to recall (media coverage, spectacular, recent), the more we overestimate its probability."
+    - question: "Why do people overestimate the risk of shark attacks?"
+      choices:
+        - "Because the media covers them extensively"
+        - "Because they are statistically frequent"
+        - "Because they live near the ocean"
+      correct: 0
+      explanation: "Shark attacks are extremely rare but heavily covered by media. Their mental availability is disproportionate to the actual risk."
+---
+
+## Definition
+
+Availability bias is the tendency to judge the probability of an event based on how easily examples come to mind.
+
+## Mechanism
+
+Our brain uses a shortcut: if something is easy to remember, it must be frequent. Spectacular, recent, or emotionally striking events are more "available" in memory, which distorts our estimation of their actual probability.
+
+## Examples
+
+- After a widely covered plane crash, flight bookings drop even though the risk hasn't changed.
+- We overestimate deaths from terrorist attacks and underestimate those from cardiovascular disease.
+- A manager who recently had a bad experience with a freelancer will refuse to hire another, even though the experience is statistically rare.

--- a/src/content/biases/availability/fr.md
+++ b/src/content/biases/availability/fr.md
@@ -1,0 +1,57 @@
+---
+slug: "de-disponibilite"
+title: "Biais de disponibilité"
+originalName: "Availability bias"
+family: "too-much-information"
+tags: ["mémoire", "probabilité", "médias"]
+difficulty: "medium"
+sources:
+  wikipedia: "https://fr.wikipedia.org/wiki/Heuristique_de_disponibilit%C3%A9"
+  papers:
+    - title: "Votre cerveau vous joue des tours — Albert Moukheiber, 2019"
+      url: "https://www.odilejacob.fr/catalogue/sciences/neurosciences/votre-cerveau-vous-joue-des-tours_9782738145826.php"
+  videos:
+    - title: "Les biais cognitifs — ScienceÉtonnante"
+      url: "https://www.youtube.com/watch?v=oFEOoEqW3bE"
+      lang: "fr"
+relatedBiases: ["anchoring", "survivorship"]
+situation:
+  type: "choice"
+  scenario: "Après avoir vu plusieurs reportages sur des accidents d'avion, vous devez prendre un vol. Que ressentez-vous ?"
+  choices:
+    - label: "L'avion est dangereux, je préfère prendre la voiture"
+      bias: true
+    - label: "Les reportages ne changent pas les statistiques, l'avion reste le transport le plus sûr"
+      bias: false
+  reveal: "Les reportages rendent les accidents d'avion très 'disponibles' dans votre mémoire, vous faisant surestimer leur fréquence. En réalité, le risque en voiture est bien plus élevé."
+quiz:
+  questions:
+    - question: "Le biais de disponibilité nous fait..."
+      choices:
+        - "Surestimer la probabilité d'événements faciles à se rappeler"
+        - "Oublier les événements récents"
+        - "Sous-estimer tous les risques"
+      correct: 0
+      explanation: "Plus un événement est facile à se rappeler (médiatisé, spectaculaire, récent), plus on surestime sa probabilité."
+    - question: "Pourquoi les gens surestiment-ils le risque d'attaque de requin ?"
+      choices:
+        - "Parce que les médias en parlent beaucoup"
+        - "Parce que c'est statistiquement fréquent"
+        - "Parce qu'ils vivent près de la mer"
+      correct: 0
+      explanation: "Les attaques de requin sont extrêmement rares mais très médiatisées. Leur disponibilité mentale est disproportionnée par rapport au risque réel."
+---
+
+## Définition
+
+Le biais de disponibilité est la tendance à évaluer la probabilité d'un événement en fonction de la facilité avec laquelle des exemples nous viennent à l'esprit.
+
+## Mécanisme
+
+Notre cerveau utilise un raccourci : si quelque chose est facile à se rappeler, c'est que ça doit être fréquent. Les événements spectaculaires, récents ou émotionnellement marquants sont plus "disponibles" en mémoire, ce qui fausse notre estimation de leur probabilité réelle.
+
+## Exemples
+
+- Après un crash aérien médiatisé, les réservations de vols baissent alors que le risque n'a pas changé.
+- On surestime le nombre de morts par attaque terroriste et on sous-estime ceux par maladie cardiovasculaire.
+- Un manager qui a vécu un échec récent avec un freelance refusera d'en embaucher un autre, même si l'expérience est statistiquement rare.

--- a/src/content/biases/bandwagon/en.md
+++ b/src/content/biases/bandwagon/en.md
@@ -1,0 +1,53 @@
+---
+slug: "bandwagon"
+title: "Bandwagon effect"
+originalName: "Bandwagon effect"
+family: "not-enough-meaning"
+tags: ["conformity", "social", "opinion"]
+difficulty: "easy"
+sources:
+  wikipedia: "https://en.wikipedia.org/wiki/Bandwagon_effect"
+  papers:
+    - title: "Effects of Group Pressure upon the Modification and Distortion of Judgments — Asch, 1951"
+      url: "https://doi.org/10.1037/10025-016"
+relatedBiases: ["confirmation", "halo-effect"]
+situation:
+  type: "choice"
+  scenario: "You're looking for a restaurant. One is packed with a line outside, the other is nearly empty. Both have similar menus. Which do you choose?"
+  choices:
+    - label: "The crowded one — if that many people go there, it must be good"
+      bias: true
+    - label: "I'll compare reviews and menus before deciding"
+      bias: false
+  reveal: "You followed the crowd without concrete information. The empty restaurant might be excellent but new. This is the bandwagon effect."
+quiz:
+  questions:
+    - question: "The bandwagon effect makes us..."
+      choices:
+        - "Adopt an opinion because many people share it"
+        - "Systematically reject the majority's view"
+        - "Form our own opinion independently"
+      correct: 0
+      explanation: "The more popular an idea is, the more inclined we are to adopt it, regardless of its truth."
+    - question: "Asch's experiment (1951) showed that..."
+      choices:
+        - "People give wrong answers to conform with the group"
+        - "People always resist social pressure"
+        - "Experts are immune to group pressure"
+      correct: 0
+      explanation: "In Asch's experiment, 75% of participants gave at least one obviously wrong answer to conform with a unanimous group."
+---
+
+## Definition
+
+The bandwagon effect is the tendency to adopt a belief, trend, or behavior simply because a large number of people do.
+
+## Mechanism
+
+We are social animals. When we see many people adopting an opinion or behavior, our brain interprets this as a signal of validity. "If everyone's doing it, it must be right." This mental shortcut saves us from analyzing every decision, but it can lead to irrational choices.
+
+## Examples
+
+- Social media trends spread through imitation, not reflection.
+- Stock market bubbles form when everyone buys because everyone is buying.
+- Political polls influence voting: people want to vote for the likely winner.

--- a/src/content/biases/bandwagon/fr.md
+++ b/src/content/biases/bandwagon/fr.md
@@ -1,0 +1,57 @@
+---
+slug: "effet-de-groupe"
+title: "Effet de groupe"
+originalName: "Bandwagon effect"
+family: "not-enough-meaning"
+tags: ["conformisme", "social", "opinion"]
+difficulty: "easy"
+sources:
+  wikipedia: "https://fr.wikipedia.org/wiki/Effet_de_mode"
+  papers:
+    - title: "Influence et manipulation — Robert Cialdini, 2004"
+      url: "https://www.babelio.com/livres/Cialdini-Influence-et-manipulation/21068"
+  videos:
+    - title: "L'expérience de Asch — PsykoCouac"
+      url: "https://www.youtube.com/watch?v=7AuFhOhOjqg"
+      lang: "fr"
+relatedBiases: ["confirmation", "halo-effect"]
+situation:
+  type: "choice"
+  scenario: "Vous cherchez un restaurant. L'un est bondé avec une file d'attente, l'autre est presque vide. Les deux ont des menus similaires. Lequel choisissez-vous ?"
+  choices:
+    - label: "Celui qui est bondé, s'il y a autant de monde c'est qu'il est bon"
+      bias: true
+    - label: "Je compare les avis et les menus avant de décider"
+      bias: false
+  reveal: "Vous avez suivi la foule sans information concrète. Le restaurant vide est peut-être excellent mais récent. C'est l'effet de groupe."
+quiz:
+  questions:
+    - question: "L'effet de groupe nous pousse à..."
+      choices:
+        - "Adopter une opinion parce que beaucoup de gens la partagent"
+        - "Rejeter systématiquement l'avis de la majorité"
+        - "Former notre propre opinion indépendamment"
+      correct: 0
+      explanation: "Plus une idée est populaire, plus nous sommes enclins à l'adopter, indépendamment de sa véracité."
+    - question: "L'expérience d'Asch (1951) a montré que..."
+      choices:
+        - "Les gens donnent une réponse fausse pour se conformer au groupe"
+        - "Les gens résistent toujours à la pression sociale"
+        - "Les experts sont immunisés contre la pression de groupe"
+      correct: 0
+      explanation: "Dans l'expérience d'Asch, 75% des participants ont donné au moins une réponse manifestement fausse pour se conformer à un groupe unanime."
+---
+
+## Définition
+
+L'effet de groupe (ou effet bandwagon) est la tendance à adopter une croyance, une mode ou un comportement simplement parce qu'un grand nombre de personnes le font.
+
+## Mécanisme
+
+Nous sommes des animaux sociaux. Quand nous voyons beaucoup de gens adopter une opinion ou un comportement, notre cerveau interprète cela comme un signal de validité. "Si tout le monde le fait, c'est que c'est bien." Ce raccourci mental nous évite de devoir analyser chaque décision, mais il peut nous mener à des choix irrationnels.
+
+## Exemples
+
+- Les tendances sur les réseaux sociaux se propagent par imitation, pas par réflexion.
+- En bourse, les bulles spéculatives naissent quand tout le monde achète parce que tout le monde achète.
+- Les sondages politiques influencent le vote : on veut voter pour le gagnant probable.

--- a/src/content/biases/dunning-kruger/en.md
+++ b/src/content/biases/dunning-kruger/en.md
@@ -1,0 +1,53 @@
+---
+slug: "dunning-kruger"
+title: "Dunning-Kruger effect"
+originalName: "Dunning-Kruger effect"
+family: "not-enough-meaning"
+tags: ["competence", "confidence", "self-assessment"]
+difficulty: "medium"
+sources:
+  wikipedia: "https://en.wikipedia.org/wiki/Dunning%E2%80%93Kruger_effect"
+  papers:
+    - title: "Unskilled and Unaware of It — Kruger & Dunning, 1999"
+      url: "https://doi.org/10.1037/0022-3514.77.6.1121"
+relatedBiases: ["confirmation"]
+situation:
+  type: "choice"
+  scenario: "After reading a 10-minute article about stock investing, a friend tells you: 'It's easy, I'm going to invest all my savings myself.' What do you think?"
+  choices:
+    - label: "He's right, investing is simple once you understand the basics"
+      bias: true
+    - label: "10 minutes of reading isn't enough to manage your investments"
+      bias: false
+  reveal: "Overestimating one's abilities after superficial exposure to a subject is typical of the Dunning-Kruger effect. True experts know just how complex the subject really is."
+quiz:
+  questions:
+    - question: "The Dunning-Kruger effect describes..."
+      choices:
+        - "Incompetent people overestimating their abilities"
+        - "Experts underestimating difficulty for others"
+        - "Both phenomena at the same time"
+      correct: 2
+      explanation: "The effect has two sides: novices overestimate their skills, and experts underestimate how difficult things are for others."
+    - question: "When is confidence highest according to Dunning-Kruger?"
+      choices:
+        - "When you're a beginner with very little knowledge"
+        - "When you have intermediate expertise"
+        - "When you're an expert"
+      correct: 0
+      explanation: "The 'peak of incompetence confidence' occurs early in learning, when you don't yet know what you don't know."
+---
+
+## Definition
+
+The Dunning-Kruger effect is a cognitive bias where people with limited competence in a domain overestimate their abilities, while experts tend to underestimate theirs.
+
+## Mechanism
+
+To accurately assess your own competence, you need to... be competent. Novices lack the knowledge required to realize the extent of their ignorance. Conversely, experts, accustomed to complexity, assume that what's easy for them is easy for everyone.
+
+## Examples
+
+- A beginner driver feels invincible after a few months on the road, while a professional driver remains cautious.
+- On social media, the least informed people on a topic are often the most assertive.
+- In the workplace, a junior employee may confidently challenge decisions made by seasoned experts.

--- a/src/content/biases/dunning-kruger/fr.md
+++ b/src/content/biases/dunning-kruger/fr.md
@@ -1,0 +1,57 @@
+---
+slug: "dunning-kruger"
+title: "Effet Dunning-Kruger"
+originalName: "Dunning-Kruger effect"
+family: "not-enough-meaning"
+tags: ["compétence", "confiance", "auto-évaluation"]
+difficulty: "medium"
+sources:
+  wikipedia: "https://fr.wikipedia.org/wiki/Effet_Dunning-Kruger"
+  papers:
+    - title: "Votre cerveau vous joue des tours — Albert Moukheiber, 2019"
+      url: "https://www.odilejacob.fr/catalogue/sciences/neurosciences/votre-cerveau-vous-joue-des-tours_9782738145826.php"
+  videos:
+    - title: "L'effet Dunning-Kruger — La Statistique expliquée à mon chat"
+      url: "https://www.youtube.com/watch?v=LVhJxJnID_A"
+      lang: "fr"
+relatedBiases: ["confirmation"]
+situation:
+  type: "choice"
+  scenario: "Après avoir lu un article de 10 minutes sur l'investissement en bourse, un ami vous dit : 'C'est facile, je vais placer toutes mes économies moi-même.' Que pensez-vous ?"
+  choices:
+    - label: "Il a raison, l'investissement c'est simple quand on comprend les bases"
+      bias: true
+    - label: "10 minutes de lecture ne suffisent pas pour gérer ses investissements"
+      bias: false
+  reveal: "Surestimer ses compétences après une exposition superficielle à un sujet est typique de l'effet Dunning-Kruger. Les vrais experts savent à quel point le sujet est complexe."
+quiz:
+  questions:
+    - question: "L'effet Dunning-Kruger décrit..."
+      choices:
+        - "Les incompétents qui surestiment leurs capacités"
+        - "Les experts qui sous-estiment la difficulté pour les autres"
+        - "Les deux phénomènes à la fois"
+      correct: 2
+      explanation: "L'effet a deux faces : les novices surestiment leurs compétences, et les experts sous-estiment la difficulté de ce qu'ils maîtrisent."
+    - question: "À quel moment la confiance est-elle la plus élevée selon Dunning-Kruger ?"
+      choices:
+        - "Quand on débute et qu'on connaît très peu le sujet"
+        - "Quand on a une expertise intermédiaire"
+        - "Quand on est expert"
+      correct: 0
+      explanation: "Le 'pic de confiance des incompétents' survient au début de l'apprentissage, quand on ne sait pas encore ce qu'on ne sait pas."
+---
+
+## Définition
+
+L'effet Dunning-Kruger est un biais cognitif par lequel les personnes peu compétentes dans un domaine surestiment leurs capacités, tandis que les experts ont tendance à sous-estimer les leurs.
+
+## Mécanisme
+
+Pour évaluer correctement ses compétences, il faut... être compétent. Les novices n'ont pas les connaissances nécessaires pour réaliser l'étendue de leur ignorance. À l'inverse, les experts, habitués à la complexité, supposent que ce qui est facile pour eux l'est pour tout le monde.
+
+## Exemples
+
+- Un conducteur débutant se sent invincible après quelques mois de permis, alors qu'un pilote professionnel reste prudent.
+- Sur les réseaux sociaux, les personnes les moins informées sur un sujet sont souvent les plus catégoriques.
+- En entreprise, un employé junior peut contester avec assurance les décisions d'experts chevronnés.

--- a/src/content/biases/halo-effect/en.md
+++ b/src/content/biases/halo-effect/en.md
@@ -1,0 +1,53 @@
+---
+slug: "halo-effect"
+title: "Halo effect"
+originalName: "Halo effect"
+family: "not-enough-meaning"
+tags: ["perception", "judgment", "appearance"]
+difficulty: "easy"
+sources:
+  wikipedia: "https://en.wikipedia.org/wiki/Halo_effect"
+  papers:
+    - title: "A Constant Error in Psychological Ratings — Thorndike, 1920"
+      url: "https://doi.org/10.1037/h0071663"
+relatedBiases: ["confirmation"]
+situation:
+  type: "choice"
+  scenario: "You need to choose between two candidates for a position. The first is well-dressed, smiling, with a firm handshake. The second is quieter and more reserved. Both have equivalent résumés. Who do you lean toward?"
+  choices:
+    - label: "The first one — he inspires confidence"
+      bias: true
+    - label: "I can't judge on these criteria, I need to compare their skills"
+      bias: false
+  reveal: "The first candidate's pleasant appearance created a positive halo that influenced your judgment of his competence. This is the halo effect."
+quiz:
+  questions:
+    - question: "The halo effect occurs when..."
+      choices:
+        - "One positive quality influences our overall judgment of a person"
+        - "We see a glowing halo around people we admire"
+        - "We judge someone based on their past actions"
+      correct: 0
+      explanation: "A single positive trait (beauty, charisma, fame) colors our perception of all of a person's other qualities."
+    - question: "Which field exploits the halo effect most?"
+      choices:
+        - "Celebrity advertising"
+        - "Scientific research"
+        - "Education"
+      correct: 0
+      explanation: "Brands use admired celebrities so that their positive image transfers to the product."
+---
+
+## Definition
+
+The halo effect is the tendency to let a positive (or negative) impression of one trait influence our judgment of a person, product, or idea as a whole.
+
+## Mechanism
+
+Our brain craves consistency. If we like someone in one regard (appearance, voice, reputation), we automatically attribute other positive qualities to them — intelligence, honesty, competence — without evidence. The reverse also works: a negative impression taints everything else.
+
+## Examples
+
+- A physically attractive person is perceived as more intelligent and trustworthy.
+- An Apple product is judged superior in every category thanks to brand image.
+- A well-dressed student often receives better evaluations from teachers.

--- a/src/content/biases/halo-effect/fr.md
+++ b/src/content/biases/halo-effect/fr.md
@@ -1,0 +1,57 @@
+---
+slug: "effet-de-halo"
+title: "Effet de halo"
+originalName: "Halo effect"
+family: "not-enough-meaning"
+tags: ["perception", "jugement", "apparence"]
+difficulty: "easy"
+sources:
+  wikipedia: "https://fr.wikipedia.org/wiki/Effet_de_halo"
+  papers:
+    - title: "Système 1 / Système 2 : Les deux vitesses de la pensée — Daniel Kahneman, 2012"
+      url: "https://www.babelio.com/livres/Kahneman-Systeme-1--Systeme-2--Les-deux-vitesses-de-la-/364930"
+  videos:
+    - title: "L'effet de halo — Horizon Gull"
+      url: "https://www.youtube.com/watch?v=TBpRqEjHTbU"
+      lang: "fr"
+relatedBiases: ["confirmation"]
+situation:
+  type: "choice"
+  scenario: "Vous devez choisir entre deux candidats pour un poste. Le premier est élégant, souriant et a une poignée de main ferme. Le second est plus discret et réservé. Les deux ont des CV équivalents. Vers qui penchez-vous ?"
+  choices:
+    - label: "Le premier, il inspire confiance"
+      bias: true
+    - label: "Je ne peux pas juger sur ces critères, je dois comparer leurs compétences"
+      bias: false
+  reveal: "L'apparence agréable du premier candidat a créé un halo positif qui influence votre jugement sur ses compétences. C'est l'effet de halo."
+quiz:
+  questions:
+    - question: "L'effet de halo se produit quand..."
+      choices:
+        - "Une qualité positive influence notre jugement global sur une personne"
+        - "On voit un halo lumineux autour des gens qu'on admire"
+        - "On juge quelqu'un sur ses actions passées"
+      correct: 0
+      explanation: "Une seule caractéristique positive (beauté, charisme, célébrité) colore notre perception de toutes les autres qualités de la personne."
+    - question: "Quel domaine exploite le plus l'effet de halo ?"
+      choices:
+        - "La publicité avec des célébrités"
+        - "La recherche scientifique"
+        - "L'éducation"
+      correct: 0
+      explanation: "Les marques utilisent des célébrités admirées pour que leur image positive se transfère au produit."
+---
+
+## Définition
+
+L'effet de halo est la tendance à laisser une impression positive (ou négative) sur un trait influencer notre jugement sur l'ensemble d'une personne, d'un produit ou d'une idée.
+
+## Mécanisme
+
+Notre cerveau aime la cohérence. Si quelqu'un nous plaît sur un aspect (apparence, voix, réputation), nous lui attribuons automatiquement d'autres qualités positives — intelligence, honnêteté, compétence — sans preuve. L'inverse fonctionne aussi : une impression négative contamine tout le reste.
+
+## Exemples
+
+- Une personne physiquement attractive est perçue comme plus intelligente et plus fiable.
+- Un produit Apple est jugé supérieur dans tous les domaines grâce à l'image de marque.
+- Un élève bien habillé reçoit souvent de meilleures évaluations de ses enseignants.

--- a/src/content/biases/loss-aversion/en.md
+++ b/src/content/biases/loss-aversion/en.md
@@ -1,0 +1,53 @@
+---
+slug: "loss-aversion"
+title: "Loss aversion"
+originalName: "Loss aversion"
+family: "need-to-act-fast"
+tags: ["decision", "risk", "emotion"]
+difficulty: "medium"
+sources:
+  wikipedia: "https://en.wikipedia.org/wiki/Loss_aversion"
+  papers:
+    - title: "Prospect Theory: An Analysis of Decision under Risk — Kahneman & Tversky, 1979"
+      url: "https://doi.org/10.2307/1914185"
+relatedBiases: ["anchoring"]
+situation:
+  type: "choice"
+  scenario: "You're offered a bet: flip a coin. Heads, you win $100. Tails, you lose $80. Do you accept?"
+  choices:
+    - label: "No, I don't want to risk losing $80"
+      bias: true
+    - label: "Yes, the expected gain is higher than the loss"
+      bias: false
+  reveal: "Mathematically, this bet is favorable (expected value of +$10). But the pain of losing $80 outweighs the pleasure of winning $100. This is loss aversion."
+quiz:
+  questions:
+    - question: "According to Kahneman and Tversky, a loss is felt approximately..."
+      choices:
+        - "Twice as strongly as an equivalent gain"
+        - "With the same intensity as a gain"
+        - "Less strongly than an equivalent gain"
+      correct: 0
+      explanation: "Losing $100 hurts about twice as much as gaining $100 feels good. This is the classic loss aversion ratio."
+    - question: "Loss aversion explains why..."
+      choices:
+        - "People hold losing investments hoping they'll recover"
+        - "People always invest in safe assets"
+        - "People prefer quick gains"
+      correct: 0
+      explanation: "Selling a losing investment makes the loss 'real.' We prefer to hold and hope, even when it's irrational."
+---
+
+## Definition
+
+Loss aversion is the tendency to feel losses much more strongly than gains of equal value. Losing hurts more than winning feels good.
+
+## Mechanism
+
+Our brain processes losses and gains asymmetrically. Losing $50 triggers a negative emotion roughly twice as intense as the pleasure of finding $50. This asymmetry drives us to avoid risk, even when the odds are in our favor.
+
+## Examples
+
+- We refuse a favorable bet because the prospect of losing paralyzes us.
+- We keep useless items because parting with them feels like a loss.
+- "Free trial" offers work because once we have something, giving it up is painful.

--- a/src/content/biases/loss-aversion/fr.md
+++ b/src/content/biases/loss-aversion/fr.md
@@ -1,0 +1,57 @@
+---
+slug: "aversion-a-la-perte"
+title: "Aversion à la perte"
+originalName: "Loss aversion"
+family: "need-to-act-fast"
+tags: ["décision", "risque", "émotion"]
+difficulty: "medium"
+sources:
+  wikipedia: "https://fr.wikipedia.org/wiki/Aversion_pour_la_perte"
+  papers:
+    - title: "Système 1 / Système 2 : Les deux vitesses de la pensée — Daniel Kahneman, 2012"
+      url: "https://www.babelio.com/livres/Kahneman-Systeme-1--Systeme-2--Les-deux-vitesses-de-la-/364930"
+  videos:
+    - title: "L'aversion à la perte — Heu?reka"
+      url: "https://www.youtube.com/watch?v=z1XO51K_e-k"
+      lang: "fr"
+relatedBiases: ["anchoring"]
+situation:
+  type: "choice"
+  scenario: "On vous propose un pari : lancer une pièce. Face, vous gagnez 100€. Pile, vous perdez 80€. Acceptez-vous ?"
+  choices:
+    - label: "Non, je ne veux pas risquer de perdre 80€"
+      bias: true
+    - label: "Oui, le gain espéré est supérieur à la perte"
+      bias: false
+  reveal: "Mathématiquement, ce pari est avantageux (espérance de +10€). Mais la douleur de perdre 80€ pèse plus que le plaisir de gagner 100€. C'est l'aversion à la perte."
+quiz:
+  questions:
+    - question: "Selon Kahneman et Tversky, une perte est ressentie environ..."
+      choices:
+        - "Deux fois plus fort qu'un gain équivalent"
+        - "Avec la même intensité qu'un gain"
+        - "Moins fort qu'un gain équivalent"
+      correct: 0
+      explanation: "Perdre 100€ fait environ deux fois plus mal que gagner 100€ ne fait plaisir. C'est le ratio classique de l'aversion à la perte."
+    - question: "L'aversion à la perte explique pourquoi..."
+      choices:
+        - "On garde un investissement perdant en espérant qu'il remonte"
+        - "On investit toujours dans les valeurs sûres"
+        - "On préfère les gains rapides"
+      correct: 0
+      explanation: "Vendre un investissement en perte rend la perte 'réelle'. On préfère garder et espérer, même quand c'est irrationnel."
+---
+
+## Définition
+
+L'aversion à la perte est la tendance à ressentir les pertes beaucoup plus fortement que les gains de même valeur. Perdre fait plus mal que gagner ne fait plaisir.
+
+## Mécanisme
+
+Notre cerveau traite les pertes et les gains de manière asymétrique. Perdre 50€ provoque une émotion négative environ deux fois plus intense que le plaisir de trouver 50€. Cette asymétrie nous pousse à éviter les risques, même quand les probabilités sont en notre faveur.
+
+## Exemples
+
+- On refuse un pari avantageux parce que la perspective de perdre nous paralyse.
+- On conserve des objets inutiles parce que s'en séparer ressemble à une perte.
+- Les offres "essai gratuit" fonctionnent parce qu'une fois qu'on possède quelque chose, y renoncer est douloureux.

--- a/src/content/biases/survivorship/en.md
+++ b/src/content/biases/survivorship/en.md
@@ -1,0 +1,53 @@
+---
+slug: "survivorship"
+title: "Survivorship bias"
+originalName: "Survivorship bias"
+family: "too-much-information"
+tags: ["statistics", "success", "selection"]
+difficulty: "easy"
+sources:
+  wikipedia: "https://en.wikipedia.org/wiki/Survivorship_bias"
+  papers:
+    - title: "Abraham Wald and the Missing Bullet Holes — Jordan Ellenberg, 2015"
+      url: "https://doi.org/10.1080/09332480.2015.1103879"
+relatedBiases: ["anchoring", "confirmation"]
+situation:
+  type: "choice"
+  scenario: "A famous entrepreneur explains that he dropped out of school at 16 to start his company. He advises young people to do the same. What do you think?"
+  choices:
+    - label: "He succeeded without a degree, proof that school isn't necessary"
+      bias: true
+    - label: "We only hear about those who succeeded, not the thousands who failed"
+      bias: false
+  reveal: "You're only seeing the survivor. For every entrepreneur who succeeds without a degree, thousands fail in anonymity. This is survivorship bias."
+quiz:
+  questions:
+    - question: "Survivorship bias means..."
+      choices:
+        - "Only considering success cases and ignoring failures"
+        - "Surviving a dangerous situation"
+        - "Believing only the strongest succeed"
+      correct: 0
+      explanation: "This bias leads us to draw conclusions from visible 'survivors' while forgetting all those who didn't make it through the process."
+    - question: "Which historical example illustrates survivorship bias?"
+      choices:
+        - "Abraham Wald's WWII aircraft analysis"
+        - "The Milgram experiment"
+        - "The Turing test"
+      correct: 0
+      explanation: "Wald showed that reinforcement should go where returning planes had NO bullet holes, because planes hit in those areas never came back."
+---
+
+## Definition
+
+Survivorship bias is the logical error of focusing on cases that "survived" a selection process while ignoring those that failed.
+
+## Mechanism
+
+We only see the winners: successful companies, famous artists, treatments that work. Failures are invisible because they don't make headlines. This distorted view leads us to overestimate our chances of success and draw flawed conclusions.
+
+## Examples
+
+- Self-help books only feature success stories, never identical paths that led to failure.
+- We think old buildings were built better, but only the sturdiest ones survived.
+- Investment funds display their track records while excluding funds that closed due to poor performance.

--- a/src/content/biases/survivorship/fr.md
+++ b/src/content/biases/survivorship/fr.md
@@ -1,0 +1,57 @@
+---
+slug: "du-survivant"
+title: "Biais du survivant"
+originalName: "Survivorship bias"
+family: "too-much-information"
+tags: ["statistique", "succès", "sélection"]
+difficulty: "easy"
+sources:
+  wikipedia: "https://fr.wikipedia.org/wiki/Biais_du_survivant"
+  papers:
+    - title: "L'art de penser clairement — Rolf Dobelli, 2013"
+      url: "https://www.babelio.com/livres/Dobelli-Lart-de-penser-clairement/500595"
+  videos:
+    - title: "Le biais du survivant — Fouloscopie"
+      url: "https://www.youtube.com/watch?v=dOCaCeBz0Xk"
+      lang: "fr"
+relatedBiases: ["anchoring", "confirmation"]
+situation:
+  type: "choice"
+  scenario: "Un entrepreneur célèbre raconte qu'il a quitté l'école à 16 ans pour créer sa startup. Il conseille aux jeunes de faire pareil. Qu'en pensez-vous ?"
+  choices:
+    - label: "Il a réussi sans diplôme, c'est la preuve que l'école n'est pas nécessaire"
+      bias: true
+    - label: "On n'entend que ceux qui ont réussi, pas les milliers qui ont échoué"
+      bias: false
+  reveal: "Vous ne voyez que le survivant. Pour chaque entrepreneur qui réussit sans diplôme, des milliers échouent dans l'anonymat. C'est le biais du survivant."
+quiz:
+  questions:
+    - question: "Le biais du survivant consiste à..."
+      choices:
+        - "Ne prendre en compte que les cas de réussite et ignorer les échecs"
+        - "Survivre à une situation dangereuse"
+        - "Croire que seuls les plus forts réussissent"
+      correct: 0
+      explanation: "Ce biais nous fait tirer des conclusions à partir des 'survivants' visibles, en oubliant tous ceux qui n'ont pas survécu au processus."
+    - question: "Quel exemple historique illustre le biais du survivant ?"
+      choices:
+        - "Les avions de la Seconde Guerre mondiale d'Abraham Wald"
+        - "L'expérience de Milgram"
+        - "Le test de Turing"
+      correct: 0
+      explanation: "Wald a montré qu'il fallait renforcer les zones SANS impacts de balles sur les avions qui rentraient, car ceux touchés à ces endroits ne revenaient jamais."
+---
+
+## Définition
+
+Le biais du survivant est l'erreur logique qui consiste à se concentrer sur les cas qui ont "survécu" à un processus de sélection, en ignorant ceux qui ont échoué.
+
+## Mécanisme
+
+Nous ne voyons que les gagnants : les entreprises qui réussissent, les artistes célèbres, les traitements qui marchent. Les échecs sont invisibles parce qu'ils ne font pas la une. Cette vision déformée nous pousse à surestimer nos chances de succès et à tirer de mauvaises conclusions.
+
+## Exemples
+
+- Les livres de développement personnel ne parlent que des success stories, jamais des parcours identiques qui ont échoué.
+- On croit que les bâtiments anciens étaient mieux construits, alors que seuls les plus solides ont survécu.
+- Les fonds d'investissement affichent leurs performances en excluant les fonds qui ont fermé (mauvais résultats).


### PR DESCRIPTION
## Summary

Add 6 new cognitive biases with full FR + EN content, bringing the catalogue from 2 to 8 biases:

- **Dunning-Kruger effect** (not-enough-meaning, medium) — overestimating competence
- **Survivorship bias** (too-much-information, easy) — focusing only on winners
- **Halo effect** (not-enough-meaning, easy) — one trait coloring overall judgment
- **Loss aversion** (need-to-act-fast, medium) — losses hurt more than gains
- **Bandwagon effect** (not-enough-meaning, easy) — following the crowd
- **Availability bias** (too-much-information, medium) — overestimating memorable events

Each bias includes: definition, mechanism, examples, interactive situation (with biased/unbiased choices), and a 2-question quiz with explanations.

## Family coverage

| Family | Before | After |
|--------|--------|-------|
| Trop d'info | 2 | 4 |
| Pas assez de sens | 1 | 4 |
| Besoin d'agir vite | 0 | 1 |
| Que retenir ? | 0 | 0 |

## Test plan

- [x] 58 unit tests passing
- [ ] Each bias page loads in FR and EN
- [ ] Situation interaction works (choice → reveal)
- [ ] Quiz works (questions → score → submission)
- [ ] Biases appear on homepage in both views (grouped + flat)
- [ ] Related biases links work between pages