### PR TITLE
test: add markdown section validation for bias content

### DIFF
--- a/src/content/__tests__/bias-sections.test.ts
+++ b/src/content/__tests__/bias-sections.test.ts
@@ -1,0 +1,79 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const BIASES_DIR = join(import.meta.dirname, "../biases");
+
+/** Required sections per locale. Order matters — they must appear in this order. */
+const REQUIRED_SECTIONS: Record<string, string[]> = {
+	fr: ["Définition", "Mécanisme", "Exemples"],
+	en: ["Definition", "Mechanism", "Examples"],
+};
+
+/** Optional sections that are allowed but not required, per locale. */
+const OPTIONAL_SECTIONS: Record<string, string[]> = {
+	fr: ["Le saviez-vous ?"],
+	en: ["Did you know?"],
+};
+
+/** Extracts h2 section titles from markdown content (after the frontmatter). */
+const extractSections = (content: string): string[] => {
+	// Remove frontmatter (between --- delimiters)
+	const body = content.replace(/^---[\s\S]*?---/, "").trim();
+	const matches = body.match(/^## (.+)$/gm);
+	return matches ? matches.map((m) => m.replace("## ", "")) : [];
+};
+
+/** Returns all bias folders (each containing locale .md files). */
+const getBiasFolders = (): string[] =>
+	readdirSync(BIASES_DIR, { withFileTypes: true })
+		.filter((d) => d.isDirectory())
+		.map((d) => d.name);
+
+describe("bias markdown sections", () => {
+	const biasFolders = getBiasFolders();
+
+	for (const folder of biasFolders) {
+		const folderPath = join(BIASES_DIR, folder);
+		const files = readdirSync(folderPath).filter((f) => f.endsWith(".md"));
+
+		for (const file of files) {
+			const locale = file.replace(".md", "");
+			const filePath = join(folderPath, file);
+			const relativePath = `${folder}/${file}`;
+
+			if (!REQUIRED_SECTIONS[locale]) continue;
+
+			const content = readFileSync(filePath, "utf-8");
+			const sections = extractSections(content);
+			const required = REQUIRED_SECTIONS[locale];
+			const optional = OPTIONAL_SECTIONS[locale] ?? [];
+			const allowed = [...required, ...optional];
+
+			it(`${relativePath} — has all required sections`, () => {
+				for (const section of required) {
+					expect(sections, `Missing required section "## ${section}" in ${relativePath}`).toContain(
+						section,
+					);
+				}
+			});
+
+			it(`${relativePath} — has no unknown sections`, () => {
+				for (const section of sections) {
+					expect(
+						allowed,
+						`Unknown section "## ${section}" in ${relativePath}. Allowed: ${allowed.join(", ")}`,
+					).toContain(section);
+				}
+			});
+
+			it(`${relativePath} — required sections are in correct order`, () => {
+				const requiredInContent = sections.filter((s) => required.includes(s));
+				expect(
+					requiredInContent,
+					`Sections out of order in ${relativePath}. Expected: ${required.join(" → ")}`,
+				).toEqual(required);
+			});
+		}
+	}
+});


### PR DESCRIPTION
## Summary

- Vitest test that validates markdown sections in all bias content files
- Checks required sections are present (Définition/Mécanisme/Exemples in FR, Definition/Mechanism/Examples in EN)
- Checks no unknown sections exist (whitelist of allowed sections)
- Checks required sections appear in correct order
- Supports optional sections (Le saviez-vous ? / Did you know?)
- 48 new tests (3 checks × 8 biases × 2 locales)

## Test plan

- [x] 106 tests passing
- [ ] Adding a bias with missing section → test fails
- [ ] Adding a bias with unknown section → test fails