### PR TITLE
content: add 'Le saviez-vous ?' section to 6 biases

### DIFF
--- a/src/content/biases/anchoring/en.md
+++ b/src/content/biases/anchoring/en.md
@@ -55,3 +55,7 @@ When estimating an unknown value, our brain looks for a reference point. The fir
 - A crossed-out price of $100 makes $60 seem like a great deal, even if the item is worth $40.
 - In salary negotiations, the first number thrown out anchors the entire discussion.
 - Restaurant menus place the most expensive dish at the top to make others seem "reasonable".
+
+## Did you know?
+
+In 1974, psychologists Amos Tversky and Daniel Kahneman conducted an experiment at the University of Oregon in the United States. They asked participants to estimate the percentage of African countries in the United Nations. Before answering, each person had to spin a rigged wheel of fortune that landed on either 10 or 65. The result: those who saw 10 estimated an average of 25%, while those who saw 65 estimated 45%. A completely arbitrary and unrelated number influenced their judgment. This experiment, published in [*Judgment under Uncertainty: Heuristics and Biases*](https://doi.org/10.1126/science.185.4157.1124) (Science, 1974), laid the foundations for anchoring bias research.

--- a/src/content/biases/anchoring/fr.md
+++ b/src/content/biases/anchoring/fr.md
@@ -55,3 +55,7 @@ Quand nous devons estimer une valeur inconnue, notre cerveau cherche un point de
 - Un prix barré à 100€ rend un prix de 60€ attractif, même si l'objet en vaut 40€.
 - En négociation salariale, le premier chiffre posé influence toute la discussion.
 - Les menus de restaurant placent le plat le plus cher en haut pour rendre les autres "raisonnables".
+
+## Le saviez-vous ?
+
+En 1974, les psychologues Amos Tversky et Daniel Kahneman ont mené une expérience à l'université de l'Oregon, aux États-Unis. Ils ont demandé à des participants d'estimer le pourcentage de pays africains membres des Nations unies. Avant de répondre, chacun devait tourner une roue de la fortune truquée qui s'arrêtait soit sur 10, soit sur 65. Résultat : ceux qui avaient vu le nombre 10 estimaient en moyenne 25%, tandis que ceux qui avaient vu 65 estimaient 45%. Un nombre totalement arbitraire et sans rapport influençait leur jugement. Cette expérience, publiée dans [*Judgment under Uncertainty: Heuristics and Biases*](https://doi.org/10.1126/science.185.4157.1124) (Science, 1974), a posé les bases de la recherche sur le biais d'ancrage.

--- a/src/content/biases/availability/en.md
+++ b/src/content/biases/availability/en.md
@@ -51,3 +51,7 @@ Our brain uses a shortcut: if something is easy to remember, it must be frequent
 - After a widely covered plane crash, flight bookings drop even though the risk hasn't changed.
 - We overestimate deaths from terrorist attacks and underestimate those from cardiovascular disease.
 - A manager who recently had a bad experience with a freelancer will refuse to hire another, even though the experience is statistically rare.
+
+## Did you know?
+
+After the September 11, 2001 attacks in the United States, air traffic dropped by 20%. Millions of Americans chose to drive rather than fly. German psychologist Gerd Gigerenzer, director at the Max Planck Institute in Berlin, studied the consequences of this shift. In his study published in [*Dread Risk, September 11, and Fatal Traffic Accidents*](https://doi.org/10.1111/j.0956-7976.2004.00668.x) (Psychological Science, 2004), he estimated that approximately 1,600 additional Americans died in road accidents in the year following 9/11 — more than the number of passengers on the hijacked planes. Availability bias had made flying seem terrifying and driving reassuring, when the statistics said the opposite.

--- a/src/content/biases/availability/fr.md
+++ b/src/content/biases/availability/fr.md
@@ -55,3 +55,7 @@ Notre cerveau utilise un raccourci : si quelque chose est facile à se rappeler,
 - Après un crash aérien médiatisé, les réservations de vols baissent alors que le risque n'a pas changé.
 - On surestime le nombre de morts par attaque terroriste et on sous-estime ceux par maladie cardiovasculaire.
 - Un manager qui a vécu un échec récent avec un freelance refusera d'en embaucher un autre, même si l'expérience est statistiquement rare.
+
+## Le saviez-vous ?
+
+Après les attentats du 11 septembre 2001 aux États-Unis, le trafic aérien a chuté de 20%. Des millions d'Américains ont préféré prendre la voiture plutôt que l'avion. Le psychologue allemand Gerd Gigerenzer, directeur au Max Planck Institute de Berlin, a étudié les conséquences de ce report. Dans son étude publiée dans [*Dread Risk, September 11, and Fatal Traffic Accidents*](https://doi.org/10.1111/j.0956-7976.2004.00668.x) (Psychological Science, 2004), il a estimé qu'environ 1 600 Américains supplémentaires sont morts dans des accidents de la route dans l'année qui a suivi le 11 septembre — soit plus que le nombre de passagers des avions détournés. Le biais de disponibilité avait rendu l'avion terrifiant et la voiture rassurante, alors que les statistiques disaient l'inverse.

--- a/src/content/biases/confirmation/en.md
+++ b/src/content/biases/confirmation/en.md
@@ -55,3 +55,7 @@ Our brain is not an impartial judge. When we hold an opinion, we unconsciously s
 - On social media, algorithms reinforce this bias by showing us content aligned with our views.
 - A recruiter convinced a candidate is good will interpret their answers more favorably.
 - In politics, we watch media that reinforce our positions and avoid outlets that challenge them.
+
+## Did you know?
+
+As early as 1620, English philosopher Francis Bacon described this bias in his work [*Novum Organum*](https://en.wikipedia.org/wiki/Novum_Organum), published in London. He recounted the example of sailors who prayed to saints to survive storms. In churches, one could find ex-votos offered by survivors — apparent proof that prayers worked. But as Bacon pointed out, no one went to ask the opinion of those who had prayed and drowned. Four centuries before psychologist Peter Wason coined the term "confirmation bias" in 1960 in London, Bacon had already described its mechanism.

--- a/src/content/biases/confirmation/fr.md
+++ b/src/content/biases/confirmation/fr.md
@@ -55,3 +55,7 @@ Notre cerveau n'est pas un juge impartial. Quand nous avons une opinion, nous ch
 - Sur les réseaux sociaux, les algorithmes renforcent ce biais en nous montrant du contenu aligné avec nos opinions.
 - Un recruteur convaincu qu'un candidat est bon interprétera ses réponses de manière plus favorable.
 - En politique, nous regardons les médias qui confortent nos positions et évitons les autres.
+
+## Le saviez-vous ?
+
+Dès 1620, le philosophe anglais Francis Bacon décrivait ce biais dans son ouvrage [*Novum Organum*](https://fr.wikipedia.org/wiki/Novum_organum), publié à Londres. Il y racontait l'exemple des marins qui priaient les saints pour survivre aux tempêtes. Dans les églises, on trouvait des ex-voto offerts par les survivants — preuve apparente de l'efficacité des prières. Mais comme Bacon le soulignait, personne n'allait demander l'avis de ceux qui avaient prié et s'étaient noyés. Quatre siècles avant que le terme "biais de confirmation" ne soit inventé par le psychologue Peter Wason en 1960 à Londres, Bacon en avait déjà décrit le mécanisme.

--- a/src/content/biases/dunning-kruger/en.md
+++ b/src/content/biases/dunning-kruger/en.md
@@ -51,3 +51,7 @@ To accurately assess your own competence, you need to... be competent. Novices l
 - A beginner driver feels invincible after a few months on the road, while a professional driver remains cautious.
 - On social media, the least informed people on a topic are often the most assertive.
 - In the workplace, a junior employee may confidently challenge decisions made by seasoned experts.
+
+## Did you know?
+
+On April 19, 1995, McArthur Wheeler robbed two banks in Pittsburgh, Pennsylvania, with his face covered in lemon juice. He was convinced the juice made him invisible to surveillance cameras, since lemon juice is used as invisible ink. Arrested that same evening thanks to the footage, he was stunned: "But I wore the juice!" This case inspired psychologists David Dunning and Justin Kruger at Cornell University to publish their landmark 1999 study [*Unskilled and Unaware of It*](https://doi.org/10.1037/0022-3514.77.6.1121) (Journal of Personality and Social Psychology), demonstrating why incompetent people fail to recognize their own incompetence.

--- a/src/content/biases/dunning-kruger/fr.md
+++ b/src/content/biases/dunning-kruger/fr.md
@@ -55,3 +55,7 @@ Pour évaluer correctement ses compétences, il faut... être compétent. Les no
 - Un conducteur débutant se sent invincible après quelques mois de permis, alors qu'un pilote professionnel reste prudent.
 - Sur les réseaux sociaux, les personnes les moins informées sur un sujet sont souvent les plus catégoriques.
 - En entreprise, un employé junior peut contester avec assurance les décisions d'experts chevronnés.
+
+## Le saviez-vous ?
+
+Le 19 avril 1995, McArthur Wheeler a braqué deux banques à Pittsburgh, en Pennsylvanie, le visage enduit de jus de citron. Il était convaincu que le jus le rendait invisible aux caméras de surveillance, puisque le citron est utilisé comme encre invisible. Arrêté le soir même grâce aux vidéos de surveillance, il a été stupéfait : "Mais j'avais mis du jus !" C'est cette affaire qui a inspiré les psychologues David Dunning et Justin Kruger de l'université Cornell à publier en 1999 leur étude fondatrice [*Unskilled and Unaware of It*](https://doi.org/10.1037/0022-3514.77.6.1121) (Journal of Personality and Social Psychology), démontrant pourquoi les personnes incompétentes ne réalisent pas leur incompétence.

--- a/src/content/biases/loss-aversion/en.md
+++ b/src/content/biases/loss-aversion/en.md
@@ -51,3 +51,7 @@ Our brain processes losses and gains asymmetrically. Losing $50 triggers a negat
 - We refuse a favorable bet because the prospect of losing paralyzes us.
 - We keep useless items because parting with them feels like a loss.
 - "Free trial" offers work because once we have something, giving it up is painful.
+
+## Did you know?
+
+In 1990, economists Daniel Kahneman, Jack Knetsch, and Richard Thaler conducted a now-famous experiment at Cornell University in New York State. They gave a university mug to half the participants and asked everyone to set a price. Those who owned the mug demanded on average twice as much to sell it (~$7) as others were willing to pay (~$3). Simply owning an object increases its perceived value — because giving it up feels like a loss. The results were published in [*Experimental Tests of the Endowment Effect*](https://doi.org/10.1086/261737) (Journal of Political Economy, 1990).

--- a/src/content/biases/loss-aversion/fr.md
+++ b/src/content/biases/loss-aversion/fr.md
@@ -55,3 +55,7 @@ Notre cerveau traite les pertes et les gains de manière asymétrique. Perdre 50
 - On refuse un pari avantageux parce que la perspective de perdre nous paralyse.
 - On conserve des objets inutiles parce que s'en séparer ressemble à une perte.
 - Les offres "essai gratuit" fonctionnent parce qu'une fois qu'on possède quelque chose, y renoncer est douloureux.
+
+## Le saviez-vous ?
+
+En 1990, les économistes Daniel Kahneman, Jack Knetsch et Richard Thaler ont mené une expérience devenue célèbre à l'université Cornell, dans l'État de New York. Ils ont donné un mug de l'université à la moitié des participants et demandé à tous de fixer un prix. Ceux qui possédaient le mug exigeaient en moyenne deux fois plus pour le vendre (~7$) que ce que les autres étaient prêts à payer (~3$). Le simple fait de posséder un objet augmente sa valeur perçue — parce que s'en séparer est ressenti comme une perte. Ces résultats ont été publiés dans [*Experimental Tests of the Endowment Effect*](https://doi.org/10.1086/261737) (Journal of Political Economy, 1990).

--- a/src/content/biases/survivorship/en.md
+++ b/src/content/biases/survivorship/en.md
@@ -51,3 +51,7 @@ We only see the winners: successful companies, famous artists, treatments that w
 - Self-help books only feature success stories, never identical paths that led to failure.
 - We think old buildings were built better, but only the sturdiest ones survived.
 - Investment funds display their track records while excluding funds that closed due to poor performance.
+
+## Did you know?
+
+In 1943, the Statistical Research Group at Columbia University in New York was tasked by the US military with optimizing bomber armor. Military engineers had mapped bullet holes on planes returning from missions over Europe and proposed reinforcing the most damaged areas. Hungarian-born statistician Abraham Wald realized the mistake: the planes they were studying were the ones that had **survived**. The areas without bullet holes were precisely the ones that, when hit, prevented the plane from returning. The undamaged areas needed reinforcement. His analysis, published in the memo [*A Method of Estimating Plane Vulnerability Based on Damage of Survivors*](https://en.wikipedia.org/wiki/Abraham_Wald#Survivorship_bias) (SRG, 1943), became the most famous example of survivorship bias.

--- a/src/content/biases/survivorship/fr.md
+++ b/src/content/biases/survivorship/fr.md
@@ -55,3 +55,7 @@ Nous ne voyons que les gagnants : les entreprises qui réussissent, les artistes
 - Les livres de développement personnel ne parlent que des success stories, jamais des parcours identiques qui ont échoué.
 - On croit que les bâtiments anciens étaient mieux construits, alors que seuls les plus solides ont survécu.
 - Les fonds d'investissement affichent leurs performances en excluant les fonds qui ont fermé (mauvais résultats).
+
+## Le saviez-vous ?
+
+En 1943, le Statistical Research Group de l'université Columbia à New York était chargé par l'armée américaine d'optimiser le blindage des bombardiers. Les ingénieurs militaires avaient cartographié les impacts de balles sur les avions qui rentraient de mission au-dessus de l'Europe et proposaient de renforcer les zones les plus touchées. Le statisticien hongrois Abraham Wald a compris l'erreur : les avions qu'ils étudiaient étaient ceux qui avaient **survécu**. Les zones sans impacts étaient justement celles qui, une fois touchées, empêchaient l'avion de revenir. Il fallait renforcer les zones intactes. Son analyse, publiée dans le mémo [*A Method of Estimating Plane Vulnerability Based on Damage of Survivors*](https://en.wikipedia.org/wiki/Abraham_Wald#Survivorship_bias) (SRG, 1943), est devenue l'exemple le plus célèbre du biais du survivant.


### PR DESCRIPTION
## Summary

Add an optional "Le saviez-vous ?" / "Did you know?" section to 6 biases with historical anecdotes, dates, locations, and linked sources:

- **Anchoring** — Tversky & Kahneman's rigged wheel of fortune experiment (Oregon, 1974)
- **Confirmation** — Francis Bacon and the sailors' prayers (London, 1620)
- **Survivorship** — Abraham Wald and the WWII bomber bullet holes (Columbia University, 1943)
- **Dunning-Kruger** — McArthur Wheeler, the lemon juice bank robber (Pittsburgh, 1995)
- **Loss aversion** — Kahneman's mug experiment (Cornell University, 1990)
- **Availability** — Gerd Gigerenzer's post-9/11 traffic death study (Max Planck Institute, 2004)

Each anecdote includes dates, locations, and linked academic sources.

## Test plan

- [ ] Section renders correctly on all 6 bias pages (FR + EN)
- [ ] Links open to correct sources
- [ ] Biases without the section (halo, bandwagon) still work fine