### PR TITLE
feat: add situation and quiz section titles

### DIFF
--- a/src/components/interactive/BiasInteractive.svelte
+++ b/src/components/interactive/BiasInteractive.svelte
@@ -66,12 +66,14 @@ const handleRecoveryDismiss = () => {
 
 {#if situation}
 	<section class="mt-12">
+		<h2 class="mb-4 text-2xl font-bold">{labels.situationTitle}</h2>
 		<Situation data={situation} onComplete={handleSituationComplete} />
 	</section>
 {/if}
 
 {#if quiz}
 	<section class="mt-12">
+		<h2 class="mb-4 text-2xl font-bold">{labels.quizTitle}</h2>
 		<Quiz data={quiz} labels={labels.quiz} onComplete={handleQuizComplete} />
 	</section>
 

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -48,6 +48,8 @@ export interface PseudoEditorLabels {
 
 /** Labels for the BiasInteractive orchestrator. */
 export interface BiasInteractiveLabels {
+	situationTitle: string;
+	quizTitle: string;
 	quiz: QuizLabels;
 	score: ScoreLabels;
 	recovery: RecoveryModalLabels;
@@ -75,6 +77,8 @@ export interface ProfilePageLabels {
 
 /** Builds all labels needed by the BiasInteractive orchestrator. */
 export const getBiasInteractiveLabels = (locale: Locale): BiasInteractiveLabels => ({
+	situationTitle: t(locale, "situation.title"),
+	quizTitle: t(locale, "quiz.title"),
 	quiz: {
 		next: t(locale, "quiz.next"),
 		results: t(locale, "quiz.results"),


### PR DESCRIPTION
## Summary

- Add `situationTitle` and `quizTitle` to `BiasInteractiveLabels`
- Display h2 titles ("Mise en situation" / "Quiz") above each interactive section
- Labels sourced from existing i18n keys (`situation.title`, `quiz.title`)

## Test plan

- [x] 106 tests passing
- [ ] Situation section shows "Mise en situation" title in FR, "Put yourself in the situation" in EN
- [ ] Quiz section shows "Quiz" title in both locales