### PR TITLE
feat: clickable family and difficulty badges

### DIFF
--- a/src/components/BiasGrid.svelte
+++ b/src/components/BiasGrid.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { BiasCardData, Difficulty, Family } from "@/lib/constants";
+import { isDifficulty, isFamily } from "@/lib/utils";
 import BiasCard from "./BiasCard.svelte";
 
 interface FamilyOption {
@@ -16,6 +17,10 @@ interface Props {
 	biases: BiasCardData[];
 	families: FamilyOption[];
 	difficulties: DifficultyOption[];
+	/** Pre-selected family filter from query params (passed by Astro SSR). */
+	initialFamily?: string | null;
+	/** Pre-selected difficulty filter from query params (passed by Astro SSR). */
+	initialDifficulty?: string | null;
 	labels: {
 		family: string;
 		difficulty: string;
@@ -23,17 +28,24 @@ interface Props {
 	};
 }
 
-const { biases, families, difficulties, labels }: Props = $props();
+const { biases, families, difficulties, initialFamily, initialDifficulty, labels }: Props =
+	$props();
 
 // svelte-ignore state_referenced_locally — props are static (from Astro), won't change after mount
 const familyKeys = families.map((family) => family.key);
 // svelte-ignore state_referenced_locally
 const difficultyKeys = difficulties.map((difficulty) => difficulty.key);
 
-/** Active family filters — all enabled by default. */
-let activeFamilies = $state(new Set(familyKeys));
-/** Active difficulty filters — all enabled by default. */
-let activeDifficulties = $state(new Set(difficultyKeys));
+/** Active family filters — narrowed to initial filter if provided, otherwise all enabled. */
+let activeFamilies = $state(
+	initialFamily && isFamily(initialFamily) ? new Set<Family>([initialFamily]) : new Set(familyKeys),
+);
+/** Active difficulty filters — narrowed to initial filter if provided, otherwise all enabled. */
+let activeDifficulties = $state(
+	initialDifficulty && isDifficulty(initialDifficulty)
+		? new Set<Difficulty>([initialDifficulty])
+		: new Set(difficultyKeys),
+);
 
 const toggleFamily = (key: Family) => {
 	const next = new Set(activeFamilies);

--- a/src/components/BiasPage.astro
+++ b/src/components/BiasPage.astro
@@ -32,21 +32,25 @@ const showOriginalName = data.originalName !== data.title;
     {showOriginalName && (
       <p class="mt-1 text-lg italic text-text-secondary">{data.originalName}</p>
     )}
-    <div class="mt-4 flex flex-wrap items-center gap-2">
-      <span
-        class="rounded-full px-2.5 py-0.5 text-xs font-medium text-white"
-        style={`background-color: var(--family-${data.family})`}
+    <div class="mt-2 flex flex-wrap gap-2 text-xs text-text-secondary">
+      {data.tags.map((tag) => (
+        <span>#{tag}</span>
+      ))}
+    </div>
+    <div class="mt-3 flex flex-wrap items-center gap-2">
+      <a
+        href={`/${locale}/?family=${data.family}`}
+        class="badge-family rounded-full border-2 px-2.5 py-0.5 text-xs font-medium no-underline transition-all duration-200"
+        style={`--family-color: var(--family-${data.family}); background-color: var(--family-color); border-color: var(--family-color); color: white`}
       >
         {t(locale, `bias.family.${data.family}`)}
-      </span>
-      <span class={`rounded-full px-2.5 py-0.5 text-xs font-medium ${DIFFICULTY_COLORS[data.difficulty]}`}>
+      </a>
+      <a
+        href={`/${locale}/?difficulty=${data.difficulty}`}
+        class={`rounded-full border-2 border-transparent px-2.5 py-0.5 text-xs font-medium no-underline transition-all duration-200 hover:bg-transparent hover:border-current ${DIFFICULTY_COLORS[data.difficulty]}`}
+      >
         {t(locale, `bias.difficulty.${data.difficulty}`)}
-      </span>
-      {data.tags.map((tag) => (
-        <span class="rounded-full border border-border px-2.5 py-0.5 text-xs text-text-secondary">
-          {tag}
-        </span>
-      ))}
+      </a>
     </div>
   </header>
 
@@ -76,3 +80,10 @@ const showOriginalName = data.originalName !== data.title;
   <!-- Related biases -->
   <BiasRelatedSection locale={locale} relatedBiases={data.relatedBiases} />
 </article>
+
+<style>
+  .badge-family:hover {
+    background-color: transparent !important;
+    color: var(--family-color) !important;
+  }
+</style>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { DIFFICULTIES, FAMILIES } from "./constants";
+import type { Difficulty, Family } from "./types";
+
+/** Type guard for Family values. */
+export const isFamily = (value: string): value is Family => FAMILIES.some((f) => f === value);
+
+/** Type guard for Difficulty values. */
+export const isDifficulty = (value: string): value is Difficulty =>
+	DIFFICULTIES.some((d) => d === value);

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -44,6 +44,11 @@ const difficultyOptions = DIFFICULTIES.map((difficulty) => ({
 
 const title = t(locale, "site.title");
 const description = t(locale, "site.description");
+
+/** Detect filter query params to render the correct initial view (SSR, no flash). */
+const filterFamily = Astro.url.searchParams.get("family");
+const filterDifficulty = Astro.url.searchParams.get("difficulty");
+const hasFilters = filterFamily !== null || filterDifficulty !== null;
 ---
 
 <BaseLayout title={title} description={description} lang={locale}>
@@ -58,21 +63,21 @@ const description = t(locale, "site.description");
     <!-- View toggle tabs -->
     <div class="mb-8 flex gap-4 border-b border-border" id="view-tabs">
       <button
-        class="border-b-2 border-accent px-4 py-2 text-sm font-medium text-accent"
+        class={`border-b-2 px-4 py-2 text-sm font-medium ${hasFilters ? "border-transparent text-text-secondary hover:text-text" : "border-accent text-accent"}`}
         data-view="grouped"
       >
         {t(locale, "home.view.grouped")}
       </button>
       <button
-        class="border-b-2 border-transparent px-4 py-2 text-sm font-medium text-text-secondary hover:text-text"
+        class={`border-b-2 px-4 py-2 text-sm font-medium ${hasFilters ? "border-accent text-accent" : "border-transparent text-text-secondary hover:text-text"}`}
         data-view="flat"
       >
         {t(locale, "home.view.flat")}
       </button>
     </div>
 
-    <!-- Grouped view (default, static HTML) -->
-    <div id="view-grouped">
+    <!-- Grouped view (hidden when filters are active) -->
+    <div id="view-grouped" class={hasFilters ? "hidden" : ""}>
       {groupedByFamily.map(({ key, label, biases: familyBiases }) => (
         <div class="mb-10">
           <h2
@@ -97,11 +102,13 @@ const description = t(locale, "site.description");
     </div>
 
     <!-- Flat view (Svelte island, hidden by default) -->
-    <div id="view-flat" class="hidden">
+    <div id="view-flat" class={hasFilters ? "" : "hidden"}>
       <BiasGrid
         biases={biasItems}
         families={familyOptions}
         difficulties={difficultyOptions}
+        initialFamily={filterFamily}
+        initialDifficulty={filterDifficulty}
         labels={{
           family: t(locale, "home.filter.family"),
           difficulty: t(locale, "home.filter.difficulty"),
@@ -114,11 +121,7 @@ const description = t(locale, "site.description");
 
   <!-- View toggle script (minimal inline JS for tab switching) -->
   <script is:inline>
-    document.getElementById("view-tabs")?.addEventListener("click", (event) => {
-      const button = event.target.closest("[data-view]");
-      if (!button) return;
-
-      const view = button.dataset.view;
+    const switchView = (view) => {
       const grouped = document.getElementById("view-grouped");
       const flat = document.getElementById("view-flat");
       const buttons = document.querySelectorAll("[data-view]");
@@ -133,6 +136,12 @@ const description = t(locale, "site.description");
         btn.classList.toggle("border-transparent", !isActive);
         btn.classList.toggle("text-text-secondary", !isActive);
       });
+    };
+
+    document.getElementById("view-tabs")?.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-view]");
+      if (!button) return;
+      switchView(button.dataset.view);
     });
   </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary

- Family and difficulty badges on bias pages are now clickable links
- Clicking navigates to homepage with pre-applied filter (`/?family=X` or `/?difficulty=X`)
- Filters resolved server-side (SSR) via `Astro.url.searchParams` — no layout flash
- `BiasGrid` accepts `initialFamily`/`initialDifficulty` props from Astro
- Homepage auto-switches to flat view when filter params are present
- Badge hover effect: outline style (transparent bg + colored text/border)
- Tags displayed as `#hashtags` on a separate line above the badges

## Test plan

- [x] 106 tests passing
- [ ] Click family badge on bias page → homepage shows only that family
- [ ] Click difficulty badge → homepage shows only that difficulty
- [ ] Normal homepage (no params) → all filters active, grouped view
- [ ] Invalid query params → ignored, all filters active
- [ ] Badge hover shows outline effect on both family and difficulty
- [ ] No layout flash when navigating with filter params