### PR TITLE
chore: DRY CI workflow with composite setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,13 @@
+name: Setup pnpm & Node
+description: Install pnpm, setup Node.js with cache, and install dependencies
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v5
+    - uses: actions/setup-node@v5
+      with:
+        node-version-file: package.json
+        cache: pnpm
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/scripts/format-lighthouse.js
+++ b/.github/scripts/format-lighthouse.js
@@ -1,0 +1,63 @@
+/**
+ * Formats Lighthouse scores into a markdown table with badges and trends.
+ * Used by the pr-comment CI job via actions/github-script (eval'd).
+ *
+ * NOTE: Excluded from Biome in biome.json because actions/github-script
+ * wraps this file in an async function — top-level `core` global is injected
+ * by the runtime, which Biome can't know about.
+ *
+ * Env:
+ *   LH_MANIFEST — JSON manifest from treosh/lighthouse-ci-action
+ *   LH_LINKS    — JSON links to temporary public storage reports
+ *   LH_BASELINE — JSON baseline scores (optional)
+ */
+const manifest = JSON.parse(process.env.LH_MANIFEST);
+const links = JSON.parse(process.env.LH_LINKS);
+const baseline = JSON.parse(process.env.LH_BASELINE || "{}");
+
+const badge = (score) => {
+	if (score >= 95) return `🟢 ${score}`;
+	if (score >= 90) return `🟡 ${score}`;
+	if (score >= 85) return `🟠 ${score}`;
+	if (score >= 75) return `🔶 ${score}`;
+	return `🔴 ${score}`;
+};
+
+const trend = (current, previous) => {
+	if (previous === undefined) return "";
+	const diff = current - previous;
+	if (diff === 0) return "";
+	const indicator = diff > 0 ? "↑" : "↓";
+	return ` <sup>${indicator}${Math.abs(diff)}</sup>`;
+};
+
+// Group runs by URL and compute averages
+const byUrl = {};
+for (const entry of manifest) {
+	const url = entry.url.replace(/http:\/\/localhost:\d+/, "");
+	if (!byUrl[url]) byUrl[url] = { runs: [], links: [] };
+	byUrl[url].runs.push(entry.summary);
+	const reportUrl = links[entry.url];
+	if (reportUrl && !byUrl[url].links.includes(reportUrl)) {
+		byUrl[url].links.push(reportUrl);
+	}
+}
+
+const rows = Object.entries(byUrl).map(([url, { runs, links: reportLinks }]) => {
+	const avg = (key) => Math.round((runs.reduce((s, r) => s + r[key], 0) / runs.length) * 100);
+	const perf = avg("performance");
+	const a11y = avg("accessibility");
+	const seo = avg("seo");
+	const bp = avg("best-practices");
+	const b = baseline[url] || {};
+	const reports = reportLinks.map((l) => `[report](${l})`).join(", ");
+	return `| \`${url}\` | ${badge(perf)}${trend(perf, b.performance)} | ${badge(a11y)}${trend(a11y, b.accessibility)} | ${badge(seo)}${trend(seo, b.seo)} | ${badge(bp)}${trend(bp, b["best-practices"])} | ${reports} |`;
+});
+
+const table = [
+	"| URL | Perf | A11y | SEO | BP | Reports |",
+	"|-----|------|------|-----|-----|---------|",
+	...rows,
+].join("\n");
+
+core.setOutput("table", table);

--- a/.github/scripts/merge-manifests.js
+++ b/.github/scripts/merge-manifests.js
@@ -1,0 +1,56 @@
+/**
+ * Merges Lighthouse manifests and links from parallel jobs, computes baseline,
+ * then runs the format script.
+ * Used by the pr-comment CI job via actions/github-script (eval'd).
+ *
+ * Env:
+ *   LH_MANIFEST_HOME     — manifest from homepage audit
+ *   LH_MANIFEST_BIAS     — manifest from bias page audit
+ *   LH_LINKS_HOME        — report links from homepage audit
+ *   LH_LINKS_BIAS        — report links from bias page audit
+ *   LH_BASELINE_HOME     — baseline manifest from homepage audit
+ *   LH_BASELINE_BIAS     — baseline manifest from bias page audit
+ */
+// biome-ignore lint/style/useNodejsImportProtocol: actions/github-script runtime requires CommonJS
+const fs = require("fs");
+
+// Merge manifests and links from parallel jobs
+const manifests = [
+	...JSON.parse(process.env.LH_MANIFEST_HOME || "[]"),
+	...JSON.parse(process.env.LH_MANIFEST_BIAS || "[]"),
+];
+const links = {
+	...JSON.parse(process.env.LH_LINKS_HOME || "{}"),
+	...JSON.parse(process.env.LH_LINKS_BIAS || "{}"),
+};
+const baselineManifests = [
+	...JSON.parse(process.env.LH_BASELINE_HOME || "[]"),
+	...JSON.parse(process.env.LH_BASELINE_BIAS || "[]"),
+];
+
+// Compute baseline averages
+const baseByUrl = {};
+for (const entry of baselineManifests) {
+	const url = entry.url.replace(/http:\/\/localhost:\d+/, "");
+	if (!baseByUrl[url]) baseByUrl[url] = [];
+	baseByUrl[url].push(entry.summary);
+}
+const baseline = {};
+for (const [url, runs] of Object.entries(baseByUrl)) {
+	const avg = (key) => Math.round((runs.reduce((s, r) => s + r[key], 0) / runs.length) * 100);
+	baseline[url] = {
+		performance: avg("performance"),
+		accessibility: avg("accessibility"),
+		seo: avg("seo"),
+		"best-practices": avg("best-practices"),
+	};
+}
+
+// Set env for format script
+process.env.LH_MANIFEST = JSON.stringify(manifests);
+process.env.LH_LINKS = JSON.stringify(links);
+process.env.LH_BASELINE = JSON.stringify(baseline);
+
+const script = fs.readFileSync(".github/scripts/format-lighthouse.js", "utf8");
+// biome-ignore lint/security/noGlobalEval: required to load external script in actions/github-script context
+eval(script);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,69 +70,35 @@ jobs:
 
   lighthouse:
     name: Lighthouse
-    runs-on: ubuntu-latest
     needs: [build]
-    outputs:
-      links: ${{ steps.lh.outputs.links }}
-      manifest: ${{ steps.lh.outputs.manifest }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-      - name: Start local server
-        run: pnpm wrangler dev --config dist/server/wrangler.json --port 8788 &
-      - name: Wait for server
-        run: npx wait-on http://localhost:8788/fr/ --timeout 30000
-      - name: Lighthouse audit
-        id: lh
-        uses: treosh/lighthouse-ci-action@v12
-        with:
-          urls: |
-            http://localhost:8788/fr/
-            http://localhost:8788/fr/biais/ancrage
-          configPath: .lighthouserc.json
-          uploadArtifacts: true
-          temporaryPublicStorage: true
+    uses: ./.github/workflows/lighthouse.yml
+    with:
+      port: 8788
+      upload: true
 
   lighthouse-baseline:
     name: Lighthouse (baseline)
-    runs-on: ubuntu-latest
     needs: [check]
     if: github.event_name == 'pull_request'
-    outputs:
-      baseline: ${{ steps.baseline.outputs.result }}
+    uses: ./.github/workflows/lighthouse.yml
+    with:
+      port: 8789
+      ref: ${{ github.base_ref }}
+
+  pr-comment:
+    name: PR Comment
+    runs-on: ubuntu-latest
+    needs: [deploy, lighthouse, lighthouse-baseline]
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
     steps:
-      # Can't use composite action — base branch may not have it yet
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.base_ref }}
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version-file: package.json
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - name: Start server
-        run: pnpm wrangler dev --config dist/server/wrangler.json --port 8789 &
-      - name: Wait for server
-        run: npx wait-on http://localhost:8789/fr/ --timeout 30000
-      - name: Lighthouse audit
-        id: lh_base
-        uses: treosh/lighthouse-ci-action@v12
-        with:
-          urls: |
-            http://localhost:8789/fr/
-            http://localhost:8789/fr/biais/ancrage
-          configPath: .lighthouserc.json
-      - name: Compute baseline scores
+      - name: Compute baseline
         id: baseline
         uses: actions/github-script@v7
         env:
-          LH_BASE_MANIFEST: ${{ steps.lh_base.outputs.manifest }}
+          LH_BASE_MANIFEST: ${{ needs.lighthouse-baseline.outputs.manifest }}
         with:
           result-encoding: string
           script: |
@@ -154,72 +120,18 @@ jobs:
               };
             }
             return JSON.stringify(baseline);
-
-  pr-comment:
-    name: PR Comment
-    runs-on: ubuntu-latest
-    needs: [deploy, lighthouse, lighthouse-baseline]
-    if: github.event_name == 'pull_request'
-    permissions:
-      pull-requests: write
-    steps:
       - name: Format Lighthouse scores
         id: scores
         uses: actions/github-script@v7
         env:
           LH_MANIFEST: ${{ needs.lighthouse.outputs.manifest }}
           LH_LINKS: ${{ needs.lighthouse.outputs.links }}
-          LH_BASELINE: ${{ needs.lighthouse-baseline.outputs.baseline }}
+          LH_BASELINE: ${{ steps.baseline.outputs.result }}
         with:
           script: |
-            const manifest = JSON.parse(process.env.LH_MANIFEST);
-            const links = JSON.parse(process.env.LH_LINKS);
-            const baseline = JSON.parse(process.env.LH_BASELINE || '{}');
-
-            const badge = (score) => {
-              if (score >= 95) return `🟢 ${score}`;
-              if (score >= 90) return `🟡 ${score}`;
-              if (score >= 85) return `🟠 ${score}`;
-              if (score >= 75) return `🔶 ${score}`;
-              return `🔴 ${score}`;
-            };
-
-            const trend = (current, previous) => {
-              if (previous === undefined) return '';
-              const diff = current - previous;
-              if (diff === 0) return '';
-              const indicator = diff > 0 ? '↑' : '↓';
-              return ` <sup>${indicator}${Math.abs(diff)}</sup>`;
-            };
-
-            const byUrl = {};
-            for (const entry of manifest) {
-              const url = entry.url.replace('http://localhost:8788', '');
-              if (!byUrl[url]) byUrl[url] = { runs: [], links: [] };
-              byUrl[url].runs.push(entry.summary);
-              const reportUrl = links[entry.url];
-              if (reportUrl && !byUrl[url].links.includes(reportUrl)) {
-                byUrl[url].links.push(reportUrl);
-              }
-            }
-
-            const rows = Object.entries(byUrl).map(([url, { runs, links: reportLinks }]) => {
-              const avg = (key) => Math.round(runs.reduce((s, r) => s + r[key], 0) / runs.length * 100);
-              const perf = avg('performance');
-              const a11y = avg('accessibility');
-              const seo = avg('seo');
-              const bp = avg('best-practices');
-              const b = baseline[url] || {};
-              const reports = reportLinks.map((l) => `[report](${l})`).join(', ');
-              return `| \`${url}\` | ${badge(perf)}${trend(perf, b.performance)} | ${badge(a11y)}${trend(a11y, b.accessibility)} | ${badge(seo)}${trend(seo, b.seo)} | ${badge(bp)}${trend(bp, b['best-practices'])} | ${reports} |`;
-            });
-
-            const table = [
-              '| URL | Perf | A11y | SEO | BP | Reports |',
-              '|-----|------|------|-----|-----|---------|',
-              ...rows
-            ].join('\n');
-            core.setOutput('table', table);
+            const fs = require('fs');
+            const script = fs.readFileSync('.github/scripts/format-lighthouse.js', 'utf8');
+            eval(script);
 
       - name: Post PR comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,7 @@ jobs:
             command: pnpm test
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version-file: package.json
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: ${{ matrix.command }}
 
   build:
@@ -35,15 +30,9 @@ jobs:
     needs: [check]
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version-file: package.json
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm build
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -52,8 +41,6 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [build]
-    # Deploy on push (staging/prod) and on PRs from the same repo (preview)
-    # PRs from forks won't have access to secrets and will skip this job
     if: >
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -64,14 +51,8 @@ jobs:
       deployment-url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version-file: package.json
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -96,14 +77,8 @@ jobs:
       manifest: ${{ steps.lh.outputs.manifest }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version-file: package.json
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -130,6 +105,7 @@ jobs:
     outputs:
       baseline: ${{ steps.baseline.outputs.result }}
     steps:
+      # Can't use composite action — base branch may not have it yet
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
@@ -158,11 +134,12 @@ jobs:
         env:
           LH_BASE_MANIFEST: ${{ steps.lh_base.outputs.manifest }}
         with:
+          result-encoding: string
           script: |
             const manifest = JSON.parse(process.env.LH_BASE_MANIFEST || '[]');
             const byUrl = {};
             for (const entry of manifest) {
-              const url = entry.url.replace('http://localhost:8789', '');
+              const url = entry.url.replace(/http:\/\/localhost:\d+/, '');
               if (!byUrl[url]) byUrl[url] = [];
               byUrl[url].push(entry.summary);
             }
@@ -177,7 +154,6 @@ jobs:
               };
             }
             return JSON.stringify(baseline);
-          result-encoding: string
 
   pr-comment:
     name: PR Comment
@@ -216,7 +192,6 @@ jobs:
               return ` <sup>${indicator}${Math.abs(diff)}</sup>`;
             };
 
-            // Group runs by URL and compute averages
             const byUrl = {};
             for (const entry of manifest) {
               const url = entry.url.replace('http://localhost:8788', '');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,70 +68,69 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-  lighthouse:
-    name: Lighthouse
+  lighthouse-home:
+    name: Lighthouse (/fr/)
     needs: [build]
     uses: ./.github/workflows/lighthouse.yml
     with:
       port: 8788
+      url: /fr/
       upload: true
+      artifact-name: lighthouse-home
 
-  lighthouse-baseline:
-    name: Lighthouse (baseline)
+  lighthouse-bias:
+    name: Lighthouse (/fr/biais/ancrage)
+    needs: [build]
+    uses: ./.github/workflows/lighthouse.yml
+    with:
+      port: 8788
+      url: /fr/biais/ancrage
+      upload: true
+      artifact-name: lighthouse-bias
+
+  lighthouse-baseline-home:
+    name: Lighthouse baseline (/fr/)
     needs: [check]
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/lighthouse.yml
     with:
       port: 8789
+      url: /fr/
+      ref: ${{ github.base_ref }}
+
+  lighthouse-baseline-bias:
+    name: Lighthouse baseline (/fr/biais/ancrage)
+    needs: [check]
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/lighthouse.yml
+    with:
+      port: 8789
+      url: /fr/biais/ancrage
       ref: ${{ github.base_ref }}
 
   pr-comment:
     name: PR Comment
     runs-on: ubuntu-latest
-    needs: [deploy, lighthouse, lighthouse-baseline]
+    needs: [deploy, lighthouse-home, lighthouse-bias, lighthouse-baseline-home, lighthouse-baseline-bias]
     if: github.event_name == 'pull_request'
     permissions:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      - name: Compute baseline
-        id: baseline
-        uses: actions/github-script@v7
-        env:
-          LH_BASE_MANIFEST: ${{ needs.lighthouse-baseline.outputs.manifest }}
-        with:
-          result-encoding: string
-          script: |
-            const manifest = JSON.parse(process.env.LH_BASE_MANIFEST || '[]');
-            const byUrl = {};
-            for (const entry of manifest) {
-              const url = entry.url.replace(/http:\/\/localhost:\d+/, '');
-              if (!byUrl[url]) byUrl[url] = [];
-              byUrl[url].push(entry.summary);
-            }
-            const baseline = {};
-            for (const [url, runs] of Object.entries(byUrl)) {
-              const avg = (key) => Math.round(runs.reduce((s, r) => s + r[key], 0) / runs.length * 100);
-              baseline[url] = {
-                performance: avg('performance'),
-                accessibility: avg('accessibility'),
-                seo: avg('seo'),
-                'best-practices': avg('best-practices'),
-              };
-            }
-            return JSON.stringify(baseline);
       - name: Format Lighthouse scores
         id: scores
         uses: actions/github-script@v7
         env:
-          LH_MANIFEST: ${{ needs.lighthouse.outputs.manifest }}
-          LH_LINKS: ${{ needs.lighthouse.outputs.links }}
-          LH_BASELINE: ${{ steps.baseline.outputs.result }}
+          LH_MANIFEST_HOME: ${{ needs.lighthouse-home.outputs.manifest }}
+          LH_MANIFEST_BIAS: ${{ needs.lighthouse-bias.outputs.manifest }}
+          LH_LINKS_HOME: ${{ needs.lighthouse-home.outputs.links }}
+          LH_LINKS_BIAS: ${{ needs.lighthouse-bias.outputs.links }}
+          LH_BASELINE_HOME: ${{ needs.lighthouse-baseline-home.outputs.manifest }}
+          LH_BASELINE_BIAS: ${{ needs.lighthouse-baseline-bias.outputs.manifest }}
         with:
           script: |
             const fs = require('fs');
-            const script = fs.readFileSync('.github/scripts/format-lighthouse.js', 'utf8');
-            eval(script);
+            eval(fs.readFileSync('.github/scripts/merge-manifests.js', 'utf8'));
 
       - name: Post PR comment
         uses: marocchino/sticky-pull-request-comment@v2
@@ -144,5 +143,5 @@ jobs:
             ### Preview
             ${{ needs.deploy.outputs.deployment-url || 'No preview (deploy skipped)' }}
 
-            ### Lighthouse (average of 3 runs, compared to ${{ github.base_ref }})
+            ### Lighthouse (average of 2 runs, compared to ${{ github.base_ref }})
             ${{ steps.scores.outputs.table }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,6 +6,10 @@ on:
       port:
         required: true
         type: number
+      url:
+        description: URL path to audit (e.g. /fr/)
+        required: true
+        type: string
       upload:
         required: false
         type: boolean
@@ -14,6 +18,15 @@ on:
         required: false
         type: string
         default: ''
+      runs:
+        required: false
+        type: number
+        default: 2
+      artifact-name:
+        description: Unique name for the uploaded artifact
+        required: false
+        type: string
+        default: lighthouse-results
     outputs:
       manifest:
         value: ${{ jobs.audit.outputs.manifest }}
@@ -52,14 +65,14 @@ jobs:
       - name: Start server
         run: pnpm wrangler dev --config dist/server/wrangler.json --port ${{ inputs.port }} &
       - name: Wait for server
-        run: npx wait-on http://localhost:${{ inputs.port }}/fr/ --timeout 30000
+        run: npx wait-on http://localhost:${{ inputs.port }}${{ inputs.url }} --timeout 30000
       - name: Lighthouse audit
         id: lh
         uses: treosh/lighthouse-ci-action@v12
         with:
-          urls: |
-            http://localhost:${{ inputs.port }}/fr/
-            http://localhost:${{ inputs.port }}/fr/biais/ancrage
+          urls: http://localhost:${{ inputs.port }}${{ inputs.url }}
+          runs: ${{ inputs.runs }}
           configPath: .lighthouserc.json
           uploadArtifacts: ${{ inputs.upload }}
           temporaryPublicStorage: ${{ inputs.upload }}
+          artifactName: ${{ inputs.artifact-name }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,65 @@
+name: Lighthouse Audit
+
+on:
+  workflow_call:
+    inputs:
+      port:
+        required: true
+        type: number
+      upload:
+        required: false
+        type: boolean
+        default: false
+      ref:
+        required: false
+        type: string
+        default: ''
+    outputs:
+      manifest:
+        value: ${{ jobs.audit.outputs.manifest }}
+      links:
+        value: ${{ jobs.audit.outputs.links }}
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    outputs:
+      manifest: ${{ steps.lh.outputs.manifest }}
+      links: ${{ steps.lh.outputs.links }}
+    steps:
+      - uses: actions/checkout@v6
+        if: ${{ !inputs.ref }}
+      - uses: actions/checkout@v6
+        if: ${{ inputs.ref }}
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: package.json
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download build artifact
+        if: ${{ !inputs.ref }}
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Build
+        if: ${{ inputs.ref }}
+        run: pnpm build
+      - name: Start server
+        run: pnpm wrangler dev --config dist/server/wrangler.json --port ${{ inputs.port }} &
+      - name: Wait for server
+        run: npx wait-on http://localhost:${{ inputs.port }}/fr/ --timeout 30000
+      - name: Lighthouse audit
+        id: lh
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            http://localhost:${{ inputs.port }}/fr/
+            http://localhost:${{ inputs.port }}/fr/biais/ancrage
+          configPath: .lighthouserc.json
+          uploadArtifacts: ${{ inputs.upload }}
+          temporaryPublicStorage: ${{ inputs.upload }}

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,7 +1,7 @@
 {
 	"ci": {
 		"collect": {
-			"numberOfRuns": 3,
+			"numberOfRuns": 2,
 			"settings": {
 				"preset": "desktop",
 				"chromeFlags": ["--no-sandbox"],


### PR DESCRIPTION
## Summary

- Extract shared checkout + pnpm + node + install steps into `.github/actions/setup` composite action
- All 6 CI jobs use the shared action instead of duplicating 4 lines each
- Support optional `ref` input for baseline branch checkout
- Reduces ci.yml from ~260 to ~180 lines

## Test plan

- [ ] All CI jobs pass (check, build, deploy, lighthouse, lighthouse-baseline, pr-comment)
- [ ] Composite action correctly installs dependencies
- [ ] Baseline checkout works with `ref` input