### PR TITLE
feat: prerender static pages (bias, about, sitemap)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,20 +2,18 @@
 import { t } from "@/i18n/i18n";
 import GithubIcon from "~icons/lucide/github";
 
-const { locale, isRegistered } = Astro.locals;
+const { locale } = Astro.locals;
 ---
 
 <footer class="border-t border-border bg-surface">
   <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-8 py-4 text-sm text-text-secondary">
     <span>Cognipedia &copy; {new Date().getFullYear()}</span>
-    {!isRegistered && (
-      <a
-        href={`/${locale}/${t(locale, "slug.profile")}`}
-        class="text-text-secondary hover:text-text no-underline hover:underline"
-      >
-        {t(locale, "footer.existing-account")}
-      </a>
-    )}
+    <a
+      href={`/${locale}/${t(locale, "slug.profile")}`}
+      class="text-text-secondary hover:text-text no-underline hover:underline"
+    >
+      {t(locale, "footer.existing-account")}
+    </a>
     <a
       href="https://github.com/Jeromearsene/cognipedia"
       target="_blank"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,15 +2,13 @@
 import type { Locale } from "@/i18n/i18n";
 import { SUPPORTED_LOCALES, t } from "@/i18n/i18n";
 
-const { locale, currentPath, altLangHrefs, isRegistered } = Astro.locals;
+const { locale, currentPath, altLangHrefs } = Astro.locals;
 
 const navLinks = [
 	{ key: "nav.home", href: `/${locale}/` },
 	{ key: "nav.leaderboard", href: `/${locale}/${t(locale, "slug.leaderboard")}` },
 	{ key: "nav.about", href: `/${locale}/${t(locale, "slug.about")}` },
-	...(isRegistered
-		? [{ key: "nav.profile", href: `/${locale}/${t(locale, "slug.profile")}` }]
-		: []),
+	{ key: "nav.profile", href: `/${locale}/${t(locale, "slug.profile")}` },
 ];
 
 /**

--- a/src/components/interactive/BiasInteractive.svelte
+++ b/src/components/interactive/BiasInteractive.svelte
@@ -59,8 +59,6 @@ const handleQuizComplete = async (correct: number, total: number) => {
 
 const handleRecoveryDismiss = () => {
 	showRecoveryModal = false;
-	// Reload so the server reads the newly set cookie and renders the "Profile" nav link
-	window.location.reload();
 };
 </script>
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -15,7 +15,5 @@ declare namespace App {
 		currentPath: string;
 		/** Alternate-language URLs for the current page, used by the language switcher. */
 		altLangHrefs?: Partial<Record<import("./i18n/i18n").Locale, string>>;
-		/** Whether the user has a registered account (read from cookie). */
-		isRegistered: boolean;
 	}
 }

--- a/src/lib/__tests__/userStore.auth.test.ts
+++ b/src/lib/__tests__/userStore.auth.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { cookieMock, localStorageMock, setupUserStoreMocks } from "./userStore.setup";
+import { localStorageMock, setupUserStoreMocks } from "./userStore.setup";
 
 setupUserStoreMocks();
 
 describe("userStore — register & recover", () => {
 	describe("register()", () => {
-		it("calls POST /api/register, persists to localStorage, and sets cookie", async () => {
+		it("calls POST /api/register and persists to localStorage", async () => {
 			const fetchMock = vi
 				.fn()
 				.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
@@ -39,14 +39,11 @@ describe("userStore — register & recover", () => {
 				"cognipedia_recovery_code",
 				userStore.recoveryCode,
 			);
-
-			// Cookie
-			expect(cookieMock.value).toContain("cognipedia_registered=1");
 		});
 	});
 
 	describe("recover()", () => {
-		it("calls POST /api/recover, updates state, and sets cookie", async () => {
+		it("calls POST /api/recover and updates state", async () => {
 			const recovered = { uuid: "recovered-uuid", pseudo: "RecoveredOwl99" };
 			const fetchMock = vi
 				.fn()
@@ -76,9 +73,6 @@ describe("userStore — register & recover", () => {
 				"cognipedia_recovery_code",
 				"COGNI-AB12-CD34",
 			);
-
-			// Cookie
-			expect(cookieMock.value).toContain("cognipedia_registered=1");
 		});
 
 		it("throws on invalid code format", async () => {

--- a/src/lib/__tests__/userStore.load.test.ts
+++ b/src/lib/__tests__/userStore.load.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { cookieMock, localStorageMock, setupUserStoreMocks } from "./userStore.setup";
+import { localStorageMock, setupUserStoreMocks } from "./userStore.setup";
 
 setupUserStoreMocks();
 
@@ -31,22 +31,6 @@ describe("userStore — load & clear", () => {
 			expect(userStore.recoveryCodeSeen).toBe(true);
 			expect(userStore.isRegistered).toBe(true);
 		});
-
-		it("renews cookie when a registered user loads", async () => {
-			localStorageMock.setItem("cognipedia_uuid", "test-uuid-123");
-
-			const { userStore } = await import("../userStore.svelte");
-			userStore.load();
-
-			expect(cookieMock.value).toContain("cognipedia_registered=1");
-		});
-
-		it("does not set cookie when no user is registered", async () => {
-			const { userStore } = await import("../userStore.svelte");
-			userStore.load();
-
-			expect(cookieMock.value).toBe("");
-		});
 	});
 
 	describe("clear()", () => {
@@ -72,16 +56,6 @@ describe("userStore — load & clear", () => {
 			expect(localStorageMock.removeItem).toHaveBeenCalledWith("cognipedia_pseudo");
 			expect(localStorageMock.removeItem).toHaveBeenCalledWith("cognipedia_recovery_code");
 			expect(localStorageMock.removeItem).toHaveBeenCalledWith("cognipedia_recovery_code_seen");
-		});
-
-		it("clears the registered cookie", async () => {
-			localStorageMock.setItem("cognipedia_uuid", "test-uuid");
-
-			const { userStore } = await import("../userStore.svelte");
-			userStore.load();
-			userStore.clear();
-
-			expect(cookieMock.value).toContain("max-age=0");
 		});
 	});
 });

--- a/src/lib/__tests__/userStore.setup.ts
+++ b/src/lib/__tests__/userStore.setup.ts
@@ -15,35 +15,14 @@ export const createLocalStorageMock = () => {
 	};
 };
 
-/** Cookie mock that captures the last value set. */
-export const createCookieMock = () => {
-	let cookieStore = "";
-	return {
-		get value() {
-			return cookieStore;
-		},
-		stub: {
-			get cookie() {
-				return cookieStore;
-			},
-			set cookie(value: string) {
-				cookieStore = value;
-			},
-		},
-	};
-};
-
 export let localStorageMock: ReturnType<typeof createLocalStorageMock>;
-export let cookieMock: ReturnType<typeof createCookieMock>;
 
-/** Sets up localStorage and document.cookie mocks. Call in each test file's top-level scope. */
+/** Sets up localStorage mock. Call in each test file's top-level scope. */
 export const setupUserStoreMocks = () => {
 	beforeEach(() => {
 		vi.resetModules();
 		localStorageMock = createLocalStorageMock();
-		cookieMock = createCookieMock();
 		vi.stubGlobal("localStorage", localStorageMock);
-		vi.stubGlobal("document", cookieMock.stub);
 	});
 
 	afterEach(() => {

--- a/src/lib/userStore.svelte.ts
+++ b/src/lib/userStore.svelte.ts
@@ -16,23 +16,6 @@ const KEYS = {
 	recoveryCodeSeen: "cognipedia_recovery_code_seen",
 } as const;
 
-const COOKIE_NAME = "cognipedia_registered";
-
-/** Max-age of 100 years. Some browsers (Safari) cap at 400 days, so we renew on each load(). */
-const COOKIE_MAX_AGE = 60 * 60 * 24 * 365 * 100;
-
-/** Sets a lightweight cookie flag so the server knows the user is registered. */
-const setRegisteredCookie = () => {
-	// biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API not widely supported yet
-	document.cookie = `${COOKIE_NAME}=1; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
-};
-
-/** Removes the registered cookie. */
-const clearRegisteredCookie = () => {
-	// biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API not widely supported yet
-	document.cookie = `${COOKIE_NAME}=; path=/; max-age=0`;
-};
-
 /** Reactive user store — manages identity in localStorage and communicates with API endpoints. */
 const createUserStore = () => {
 	let uuid = $state<string | null>(null);
@@ -48,11 +31,6 @@ const createUserStore = () => {
 			pseudo = localStorage.getItem(KEYS.pseudo);
 			recoveryCode = localStorage.getItem(KEYS.recoveryCode);
 			recoveryCodeSeen = localStorage.getItem(KEYS.recoveryCodeSeen) === "true";
-
-			// Renew cookie on each load to counter browsers that cap max-age (e.g. Safari 400 days)
-			if (uuid) {
-				setRegisteredCookie();
-			}
 		} catch (err) {
 			console.warn("[userStore] localStorage unavailable, keeping default state", err);
 		}
@@ -89,7 +67,6 @@ const createUserStore = () => {
 		localStorage.setItem(KEYS.uuid, newUuid);
 		localStorage.setItem(KEYS.pseudo, newPseudo);
 		localStorage.setItem(KEYS.recoveryCode, newRecoveryCode);
-		setRegisteredCookie();
 	};
 
 	/**
@@ -122,7 +99,6 @@ const createUserStore = () => {
 		localStorage.setItem(KEYS.pseudo, data.pseudo);
 		localStorage.setItem(KEYS.recoveryCode, code);
 		localStorage.setItem(KEYS.recoveryCodeSeen, "true");
-		setRegisteredCookie();
 	};
 
 	/** Marks the recovery code as seen by the user and persists to localStorage. */
@@ -165,7 +141,6 @@ const createUserStore = () => {
 		localStorage.removeItem(KEYS.pseudo);
 		localStorage.removeItem(KEYS.recoveryCode);
 		localStorage.removeItem(KEYS.recoveryCodeSeen);
-		clearRegisteredCookie();
 	};
 
 	return {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,10 +18,6 @@ export const onRequest = defineMiddleware((context, next) => {
 	const { url, request } = context;
 	const langSegment = url.pathname.split("/")[1];
 
-	// Read registered cookie flag
-	const cookies = request.headers.get("cookie") ?? "";
-	context.locals.isRegistered = cookies.includes("cognipedia_registered=1");
-
 	// Skip locale validation for API routes, sitemap, and root
 	if (langSegment === "api" || langSegment === "sitemap.xml" || url.pathname === "/") {
 		context.locals.locale = getLocaleFromUrl(url);

--- a/src/pages/[lang]/a-propos.astro
+++ b/src/pages/[lang]/a-propos.astro
@@ -1,4 +1,10 @@
 ---
+export const prerender = true;
+
+import type { GetStaticPaths } from "astro";
+
+export const getStaticPaths: GetStaticPaths = () => [{ params: { lang: "fr" } }];
+
 /** About page (French route: /fr/a-propos). */
 import AboutPage from "@/components/AboutPage.astro";
 import { t } from "@/i18n/i18n";

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -1,4 +1,10 @@
 ---
+export const prerender = true;
+
+import type { GetStaticPaths } from "astro";
+
+export const getStaticPaths: GetStaticPaths = () => [{ params: { lang: "en" } }];
+
 /** About page (English route: /en/about). */
 import AboutPage from "@/components/AboutPage.astro";
 import { t } from "@/i18n/i18n";

--- a/src/pages/[lang]/biais/[slug].astro
+++ b/src/pages/[lang]/biais/[slug].astro
@@ -1,14 +1,18 @@
 ---
+export const prerender = true;
+
+import type { GetStaticPaths } from "astro";
 import BiasPage from "@/components/BiasPage.astro";
 import { SUPPORTED_LOCALES, t } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBiasesForLocale } from "@/lib/biases";
 
-/**
- * French bias page — renders a single cognitive bias entry.
- * URL pattern: /:lang/biais/:slug (e.g. /fr/biais/ancrage).
- * Locale redirects are handled by the middleware.
- */
+export const getStaticPaths: GetStaticPaths = async () => {
+	const { localized } = await getBiasesForLocale("fr");
+	return localized.map((bias) => ({
+		params: { lang: "fr", slug: bias.data.slug },
+	}));
+};
 
 const { locale } = Astro.locals;
 const { slug } = Astro.params;

--- a/src/pages/[lang]/bias/[slug].astro
+++ b/src/pages/[lang]/bias/[slug].astro
@@ -1,14 +1,18 @@
 ---
+export const prerender = true;
+
+import type { GetStaticPaths } from "astro";
 import BiasPage from "@/components/BiasPage.astro";
 import { SUPPORTED_LOCALES, t } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBiasesForLocale } from "@/lib/biases";
 
-/**
- * English bias page — renders a single cognitive bias entry.
- * URL pattern: /:lang/bias/:slug (e.g. /en/bias/anchoring).
- * Locale redirects are handled by the middleware.
- */
+export const getStaticPaths: GetStaticPaths = async () => {
+	const { localized } = await getBiasesForLocale("en");
+	return localized.map((bias) => ({
+		params: { lang: "en", slug: bias.data.slug },
+	}));
+};
 
 const { locale } = Astro.locals;
 const { slug } = Astro.params;

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,3 +1,5 @@
+export const prerender = true;
+
 import type { APIRoute } from "astro";
 import { SUPPORTED_LOCALES, t } from "@/i18n/i18n";
 import { getBiasesForLocale } from "@/lib/biases";


### PR DESCRIPTION
## Summary

### Prerendered pages (static HTML served from CDN)
- **Bias pages** (16 pages: 8 biases × FR/EN) with `getStaticPaths` from content collection
- **About pages** (FR + EN)
- **Sitemap** (static XML generated at build time)

### SSR pages (unchanged)
- Homepage (query params for filters)
- Leaderboard (D1 data)
- Profile (user data)
- API routes

### Simplifications
- Header: Profile link always visible (no conditional)
- Footer: "Déjà un compte ?" always visible
- Middleware: no longer reads `isRegistered` cookie
- `isRegistered` removed from `App.Locals`

### Why
- Static pages served from CDN (~20ms vs ~200ms SSR)
- Reduces Workers invocations (important at scale with 200+ biases)
- Compatible with future features (vu/complété badges as client-side Svelte islands)

## Test plan

- [x] 125 tests passing
- [x] Build succeeds (16 bias pages + 2 about + sitemap generated)
- [ ] Bias pages render correctly in dev
- [ ] About pages render correctly
- [ ] Sitemap generated at /sitemap.xml
- [ ] SSR pages still work (homepage filters, leaderboard, profile)
- [ ] Header shows Profile link for all users
- [ ] Footer shows "Déjà un compte ?" for all users