### PR TITLE
fix: migrate deploy from Cloudflare Pages to Workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,18 @@ jobs:
         with:
           name: dist
           path: dist/
-      - name: Deploy to Cloudflare Pages
+      - name: Deploy to Cloudflare Workers
         id: deploy
         run: |
-          BRANCH=${{ github.head_ref || github.ref_name }}
-          OUTPUT=$(pnpm wrangler pages deploy dist/ --project-name cognipedia --branch "$BRANCH" --commit-dirty=true 2>&1)
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Production/staging deploy
+            OUTPUT=$(pnpm wrangler deploy --config dist/server/wrangler.json 2>&1)
+          else
+            # PR preview — upload version without promoting
+            OUTPUT=$(pnpm wrangler versions upload --config dist/server/wrangler.json 2>&1)
+          fi
           echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -o 'https://[^ ]*\.pages\.dev' | head -1)
+          URL=$(echo "$OUTPUT" | grep -o 'https://[^ ]*\.workers\.dev' | head -1)
           echo "deployment-url=$URL" >> "$GITHUB_OUTPUT"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

@astrojs/cloudflare v13 dropped Cloudflare Pages support in favor of Workers. Our CI was using `wrangler pages deploy` which uploaded files but didn't configure the SSR worker, causing 404 on all preview URLs.

### Changes
- Replace `wrangler pages deploy dist/` with `wrangler deploy --config dist/server/wrangler.json`
- PR previews use `wrangler versions upload` (creates a version without promoting to production)
- Uses the `wrangler.json` generated by the Astro adapter (includes Worker entrypoint, assets, D1 bindings)

### Impact
- Production deploy: `wrangler deploy` promotes to production
- PR preview: `wrangler versions upload` returns a preview URL
- Staging: handled via `wrangler deploy` on push to staging branch

### Note
After merging, the custom domain `cognipedia.org` may need to be reconfigured from Pages to Workers in the Cloudflare dashboard.

## Test plan

- [ ] CI deploy succeeds on push to staging
- [ ] PR preview URL is accessible
- [ ] SSR routes work (homepage, leaderboard, profile)
- [ ] API routes work (register, scores, leaderboard)
- [ ] Static assets served correctly (CSS, JS)