### PR TITLE
feat: responsive layout with mobile burger menu

### DIFF
--- a/src/components/BiasGrid.svelte
+++ b/src/components/BiasGrid.svelte
@@ -75,7 +75,7 @@ const filtered = $derived(
 );
 </script>
 
-<div class="sticky top-0 z-10 mb-6 flex flex-wrap gap-6 rounded-xl border border-accent/20 bg-accent-subtle p-4 shadow-sm">
+<div class="sticky top-0 z-10 mb-6 flex flex-wrap gap-4 rounded-xl border border-accent/20 bg-accent-subtle p-3 shadow-sm sm:gap-6 sm:p-4">
   <div>
     <span class="mb-2 block font-heading text-base font-semibold text-text">{labels.family}</span>
     <div class="flex flex-wrap gap-2">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ const { locale } = Astro.locals;
 ---
 
 <footer class="border-t border-border bg-surface">
-  <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-8 py-4 text-sm text-text-secondary">
+  <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 text-sm text-text-secondary sm:px-8">
     <span>Cognipedia &copy; {new Date().getFullYear()}</span>
     <a
       href={`/${locale}/${t(locale, "slug.profile")}`}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,5 @@
 ---
+import MobileMenu from "@/components/MobileMenu.svelte";
 import ThemeToggle from "@/components/ThemeToggle.svelte";
 import type { Locale } from "@/i18n/i18n";
 import { SUPPORTED_LOCALES, t } from "@/i18n/i18n";
@@ -24,15 +25,28 @@ const switchLangPath = (target: Locale) => {
 	const path = `/${segments.join("/")}`;
 	return currentPath.endsWith("/") ? `${path}/` : path;
 };
+
+const mobileNavLinks = navLinks.map(({ key, href }) => ({
+	label: t(locale, key),
+	href,
+	active: currentPath === href,
+}));
+
+const mobileLangLinks = SUPPORTED_LOCALES.map((lang) => ({
+	lang,
+	href: switchLangPath(lang),
+	active: lang === locale,
+}));
 ---
 
 <header class="border-b border-border bg-surface">
-  <nav class="mx-auto flex w-full max-w-6xl items-center justify-between px-8 py-4">
+  <nav class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 sm:px-8">
     <a href={`/${locale}/`} class="text-xl font-bold text-text no-underline hover:no-underline">
       Cognipedia
     </a>
 
-    <ul class="flex gap-6 list-none m-0 p-0">
+    <!-- Desktop nav (hidden below lg) -->
+    <ul class="hidden lg:flex gap-6 list-none m-0 p-0">
       {navLinks.map(({ key, href }) => (
         <li>
           <a
@@ -48,7 +62,8 @@ const switchLangPath = (target: Locale) => {
       ))}
     </ul>
 
-    <div class="flex gap-2 text-sm">
+    <!-- Desktop language switcher (hidden below lg) -->
+    <div class="hidden lg:flex gap-2 text-sm">
       {SUPPORTED_LOCALES.map((lang) => (
         <a
           href={switchLangPath(lang)}
@@ -62,6 +77,16 @@ const switchLangPath = (target: Locale) => {
       ))}
     </div>
 
-    <ThemeToggle client:load />
+    <!-- Theme toggle: desktop only (mobile version is inside MobileMenu) -->
+    <div class="hidden lg:block">
+      <ThemeToggle client:load />
+    </div>
+
+    <!-- Mobile burger (hidden above lg) -->
+    <MobileMenu
+      navLinks={mobileNavLinks}
+      langLinks={mobileLangLinks}
+      client:load
+    />
   </nav>
 </header>

--- a/src/components/MobileMenu.svelte
+++ b/src/components/MobileMenu.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+import { Menu, X } from "lucide-svelte";
+import ThemeToggle from "./ThemeToggle.svelte";
+
+interface NavLink {
+	label: string;
+	href: string;
+	active: boolean;
+}
+
+interface LangLink {
+	lang: string;
+	href: string;
+	active: boolean;
+}
+
+interface Props {
+	navLinks: NavLink[];
+	langLinks: LangLink[];
+}
+
+const { navLinks, langLinks }: Props = $props();
+
+let open = $state(false);
+
+const toggle = () => {
+	open = !open;
+	document.body.style.overflow = open ? "hidden" : "";
+};
+
+const close = () => {
+	open = false;
+	document.body.style.overflow = "";
+};
+</script>
+
+<!-- Burger button -->
+<button
+	onclick={toggle}
+	class="cursor-pointer rounded-lg border border-border bg-surface p-2 text-text transition-colors hover:bg-bg lg:hidden"
+	aria-label={open ? "Fermer le menu" : "Ouvrir le menu"}
+	aria-expanded={open}
+	type="button"
+>
+	{#if open}
+		<X size={24} />
+	{:else}
+		<Menu size={24} />
+	{/if}
+</button>
+
+<!-- Fullscreen overlay menu -->
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex flex-col bg-bg lg:hidden"
+		role="dialog"
+		aria-modal="true"
+	>
+		<div class="flex justify-end p-4">
+			<button
+				onclick={close}
+				class="cursor-pointer rounded-lg border border-border bg-surface p-2 text-text transition-colors hover:bg-bg"
+				aria-label="Fermer le menu"
+				type="button"
+			>
+				<X size={24} />
+			</button>
+		</div>
+
+		<nav class="flex flex-1 flex-col items-center justify-center gap-6">
+			{#each navLinks as { label, href, active }}
+				<a
+					{href}
+					class="font-heading text-2xl font-semibold no-underline transition-colors {active
+						? 'text-accent'
+						: 'text-text hover:text-accent'}"
+				>
+					{label}
+				</a>
+			{/each}
+		</nav>
+
+		<div class="flex flex-col items-center gap-6 pb-8">
+			<ThemeToggle />
+			<div class="flex justify-center gap-4 text-sm">
+				{#each langLinks as { lang, href, active }}
+					<a
+						{href}
+						class="uppercase no-underline transition-colors {active
+							? 'font-bold text-accent'
+							: 'text-text-secondary hover:text-accent'}"
+					>
+						{lang}
+					</a>
+				{/each}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -34,7 +34,7 @@ const { title, description = "", lang = DEFAULT_LOCALE } = Astro.props;
   </head>
   <body class="flex min-h-dvh flex-col">
     <Header />
-    <main class="mx-auto w-full max-w-6xl flex-1 p-8">
+    <main class="mx-auto w-full max-w-6xl flex-1 p-4 sm:p-8">
       <slot />
     </main>
     <Footer />

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -53,8 +53,8 @@ const hasFilters = filterFamily !== null || filterDifficulty !== null;
 
 <BaseLayout title={title} description={description} lang={locale}>
   <!-- Hero -->
-  <section class="flex flex-col items-center gap-4 py-16 text-center">
-    <h1 class="text-5xl font-bold text-accent">{title}</h1>
+  <section class="flex flex-col items-center gap-4 py-8 text-center sm:py-16">
+    <h1 class="text-3xl font-bold text-accent sm:text-5xl">{title}</h1>
     <p class="max-w-lg text-lg font-medium italic text-text-secondary">{description}</p>
   </section>
 


### PR DESCRIPTION
## Summary

- **Responsive spacing**: Reduced padding (`p-4 sm:p-8`) and hero size (`text-3xl sm:text-5xl`) on mobile
- **Burger menu**: Fullscreen mobile menu below `lg` (1024px) with large, well-spaced links for easy tapping
- **Footer**: Matching responsive padding
- **Filter bar**: Tighter spacing on mobile (`p-3 sm:p-4`)

## Test plan

- [ ] Resize browser below 1024px — burger icon appears, desktop nav hides
- [ ] Click burger — fullscreen menu opens, body scroll locked
- [ ] Click a link or close button — menu closes
- [ ] Theme toggle remains visible at all screen sizes
- [ ] Language switcher in mobile menu works correctly
- [ ] Check padding/spacing on mobile vs desktop
- [ ] Test on actual mobile device (iOS Safari, Android Chrome)