### PR TITLE
feat: page transitions and card animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@astrojs/svelte": "^8.0.3",
 		"@fontsource-variable/fraunces": "^5.2.9",
 		"@fontsource-variable/space-grotesk": "^5.2.10",
+		"@formkit/auto-animate": "^0.9.0",
 		"@levita-js/svelte": "^0.3.1",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@fontsource-variable/space-grotesk':
         specifier: ^5.2.10
         version: 5.2.10
+      '@formkit/auto-animate':
+        specifier: ^0.9.0
+        version: 0.9.0
       '@levita-js/svelte':
         specifier: ^0.3.1
         version: 0.3.1(svelte@5.53.2)
@@ -541,6 +544,9 @@ packages:
 
   '@fontsource-variable/space-grotesk@5.2.10':
     resolution: {integrity: sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==}
+
+  '@formkit/auto-animate@0.9.0':
+    resolution: {integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==}
 
   '@iconify-json/lucide@1.2.98':
     resolution: {integrity: sha512-Lx2464W8Tty/QEnZ2UPb73nPdML/HpGCj0J0w37jP3/jx3l4fniZBjDxe1TgHiIL5XW9QO3vlx53ZQZ5JsNpzQ==}
@@ -3391,6 +3397,8 @@ snapshots:
   '@fontsource-variable/fraunces@5.2.9': {}
 
   '@fontsource-variable/space-grotesk@5.2.10': {}
+
+  '@formkit/auto-animate@0.9.0': {}
 
   '@iconify-json/lucide@1.2.98':
     dependencies:

--- a/src/components/BiasCard.svelte
+++ b/src/components/BiasCard.svelte
@@ -1,14 +1,29 @@
 <script lang="ts">
+import { fade } from "svelte/transition";
 import type { BiasCardData } from "@/lib/constants";
 import { DIFFICULTY_COLORS } from "@/lib/constants";
 
-const { href, title, family, familyLabel, difficulty, difficultyLabel }: BiasCardData = $props();
+interface Props extends BiasCardData {
+	/** Stagger delay in ms for fade-in animation (defaults to 0). */
+	delay?: number;
+}
+
+const {
+	href,
+	title,
+	family,
+	familyLabel,
+	difficulty,
+	difficultyLabel,
+	delay = 0,
+}: Props = $props();
 </script>
 
 <a
   {href}
   class="bias-card block rounded-xl border border-border bg-surface p-5 no-underline shadow-sm"
   style="--glow-color: var(--family-{family})"
+  in:fade={{ duration: 300, delay }}
 >
   <h3 class="mb-3 text-lg font-semibold text-text">{title}</h3>
   <div class="flex flex-wrap gap-2">

--- a/src/components/BiasGrid.svelte
+++ b/src/components/BiasGrid.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import autoAnimate from "@formkit/auto-animate";
 import {
 	type BiasCardData,
 	DIFFICULTY_COLORS,
@@ -7,6 +8,11 @@ import {
 } from "@/lib/constants";
 import { isDifficulty, isFamily } from "@/lib/utils";
 import BiasCard from "./BiasCard.svelte";
+
+/** Svelte action wrapping @formkit/auto-animate for smooth list transitions. */
+const autoAnimateAction = (node: HTMLElement) => {
+	autoAnimate(node, { duration: 250, easing: "ease-in-out" });
+};
 
 interface FamilyOption {
 	key: Family;
@@ -114,9 +120,9 @@ const filtered = $derived(
 {#if filtered.length === 0}
   <p class="py-12 text-center text-text-secondary">{labels.noResults}</p>
 {:else}
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-    {#each filtered as bias (bias.href)}
-      <BiasCard {...bias} />
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" use:autoAnimateAction>
+    {#each filtered as bias, index (bias.href)}
+      <BiasCard {...bias} delay={Math.min(index * 40, 400)} />
     {/each}
   </div>
 {/if}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "@/styles/global.css";
+import { ClientRouter } from "astro:transitions";
 import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 import type { Locale } from "@/i18n/i18n";
@@ -30,11 +31,12 @@ const { title, description = "", lang = DEFAULT_LOCALE } = Astro.props;
         }
       })();
     </script>
+    <ClientRouter />
     <title>{title}</title>
   </head>
   <body class="flex min-h-dvh flex-col">
     <Header />
-    <main class="mx-auto w-full max-w-6xl flex-1 p-4 sm:p-8">
+    <main class="mx-auto w-full max-w-6xl flex-1 p-4 sm:p-8" transition:animate="fade">
       <slot />
     </main>
     <Footer />

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -120,11 +120,11 @@ const hasFilters = filterFamily !== null || filterDifficulty !== null;
   </section>
 
   <!-- View toggle script (minimal inline JS for tab switching) -->
-  <script is:inline>
-    const switchView = (view) => {
+  <script>
+    const switchView = (view: string) => {
       const grouped = document.getElementById("view-grouped");
       const flat = document.getElementById("view-flat");
-      const buttons = document.querySelectorAll("[data-view]");
+      const buttons = document.querySelectorAll<HTMLButtonElement>("[data-view]");
 
       grouped?.classList.toggle("hidden", view !== "grouped");
       flat?.classList.toggle("hidden", view !== "flat");
@@ -142,10 +142,16 @@ const hasFilters = filterFamily !== null || filterDifficulty !== null;
       });
     };
 
-    document.getElementById("view-tabs")?.addEventListener("click", (event) => {
-      const button = event.target.closest("[data-view]");
-      if (!button) return;
-      switchView(button.dataset.view);
-    });
+    // Re-attach listeners on every page load (initial + Astro client-side navigations).
+    const attachTabListener = () => {
+      document.getElementById("view-tabs")?.addEventListener("click", (event) => {
+        if (!(event.target instanceof Element)) return;
+        const button = event.target.closest<HTMLButtonElement>("[data-view]");
+        if (!button?.dataset.view) return;
+        switchView(button.dataset.view);
+      });
+    };
+
+    document.addEventListener("astro:page-load", attachTabListener);
   </script>
 </BaseLayout>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -88,8 +88,8 @@ const hasFilters = filterFamily !== null || filterDifficulty !== null;
           </h2>
           {familyBiases.length > 0 ? (
             <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {familyBiases.map((bias) => (
-                <BiasCard {...bias} client:visible />
+              {familyBiases.map((bias, index) => (
+                <BiasCard {...bias} delay={Math.min(index * 40, 400)} client:visible />
               ))}
             </div>
           ) : (


### PR DESCRIPTION
## Summary

- **Page transitions** — fade between pages via Astro View Transitions (native)
- **Grid animations** — @formkit/auto-animate smooths card reordering when filtering
- **Staggered fade-in** — cards fade in one after another on load (capped at 400ms total)

## Test plan

- [ ] Navigate between pages — smooth fade transition
- [ ] Toggle filters on catalogue (Tous view) — cards animate in/out smoothly
- [ ] Reload homepage — cards fade in with stagger
- [ ] Verify no animation jank on slow devices