### PR TITLE
feat: filter bar enhancements (search, counter, reset)

### DIFF
--- a/src/components/BiasGrid.svelte
+++ b/src/components/BiasGrid.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import autoAnimate from "@formkit/auto-animate";
-import { Search } from "lucide-svelte";
+import { RotateCcw, Search } from "lucide-svelte";
 import {
 	type BiasCardData,
 	DIFFICULTY_COLORS,
@@ -38,6 +38,7 @@ interface Props {
 		difficulty: string;
 		search: string;
 		searchPlaceholder: string;
+		reset: string;
 		resultsCount: string;
 		resultsCountPlural: string;
 		noResults: string;
@@ -99,6 +100,20 @@ const resultsLabel = $derived(
 		String(filtered.length),
 	),
 );
+
+/** True when any filter is narrowed (at least one family/difficulty disabled or search active). */
+const hasActiveFilters = $derived(
+	activeFamilies.size < familyKeys.length ||
+		activeDifficulties.size < difficultyKeys.length ||
+		searchQuery.trim().length > 0,
+);
+
+/** Restore all filters to their default state: everything enabled, search cleared. */
+const resetFilters = () => {
+	activeFamilies = new Set(familyKeys);
+	activeDifficulties = new Set(difficultyKeys);
+	searchQuery = "";
+};
 </script>
 
 <div class="sticky top-0 z-10 mb-6 flex flex-wrap gap-4 rounded-xl border border-accent/20 bg-accent-subtle p-3 shadow-sm sm:gap-6 sm:p-4">
@@ -151,10 +166,27 @@ const resultsLabel = $derived(
   </div>
 </div>
 
+<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+  {#if filtered.length > 0}
+    <p class="text-sm text-text-secondary">{resultsLabel}</p>
+  {:else}
+    <span></span>
+  {/if}
+  {#if hasActiveFilters}
+    <button
+      type="button"
+      onclick={resetFilters}
+      class="flex cursor-pointer items-center gap-1.5 text-sm text-text-secondary transition-colors hover:text-accent"
+    >
+      <RotateCcw size={14} />
+      {labels.reset}
+    </button>
+  {/if}
+</div>
+
 {#if filtered.length === 0}
   <p class="py-12 text-center text-text-secondary">{labels.noResults}</p>
 {:else}
-  <p class="mb-3 text-sm text-text-secondary">{resultsLabel}</p>
   <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" use:autoAnimateAction>
     {#each filtered as bias, index (bias.href)}
       <BiasCard {...bias} delay={Math.min(index * 40, 400)} />

--- a/src/components/BiasGrid.svelte
+++ b/src/components/BiasGrid.svelte
@@ -38,6 +38,8 @@ interface Props {
 		difficulty: string;
 		search: string;
 		searchPlaceholder: string;
+		resultsCount: string;
+		resultsCountPlural: string;
 		noResults: string;
 	};
 }
@@ -89,6 +91,14 @@ const filtered = $derived.by(() => {
 		return true;
 	});
 });
+
+/** Formatted result count: picks singular/plural template and injects the number. */
+const resultsLabel = $derived(
+	(filtered.length <= 1 ? labels.resultsCount : labels.resultsCountPlural).replace(
+		"{count}",
+		String(filtered.length),
+	),
+);
 </script>
 
 <div class="sticky top-0 z-10 mb-6 flex flex-wrap gap-4 rounded-xl border border-accent/20 bg-accent-subtle p-3 shadow-sm sm:gap-6 sm:p-4">
@@ -144,6 +154,7 @@ const filtered = $derived.by(() => {
 {#if filtered.length === 0}
   <p class="py-12 text-center text-text-secondary">{labels.noResults}</p>
 {:else}
+  <p class="mb-3 text-sm text-text-secondary">{resultsLabel}</p>
   <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" use:autoAnimateAction>
     {#each filtered as bias, index (bias.href)}
       <BiasCard {...bias} delay={Math.min(index * 40, 400)} />

--- a/src/components/BiasGrid.svelte
+++ b/src/components/BiasGrid.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
 import autoAnimate from "@formkit/auto-animate";
-import { RotateCcw, Search } from "lucide-svelte";
-import {
-	type BiasCardData,
-	DIFFICULTY_COLORS,
-	type Difficulty,
-	type Family,
-} from "@/lib/constants";
+import type { BiasCardData, Difficulty, Family } from "@/lib/constants";
 import { isDifficulty, isFamily } from "@/lib/utils";
 import BiasCard from "./BiasCard.svelte";
+import FilterBar from "./FilterBar.svelte";
+import ResultsHeader from "./ResultsHeader.svelte";
 
 /** Svelte action wrapping @formkit/auto-animate for smooth list transitions. */
 const autoAnimateAction = (node: HTMLElement) => {
@@ -120,73 +116,30 @@ const resetFilters = () => {
 };
 </script>
 
-<div class="sticky top-0 z-10 mb-6 flex flex-wrap gap-4 rounded-xl border border-accent/20 bg-accent-subtle p-3 shadow-sm sm:gap-6 sm:p-4">
-  <div class="w-full sm:w-auto sm:min-w-[220px] sm:flex-1">
-    <label for="bias-search" class="mb-2 block font-heading text-base font-semibold text-text">{labels.search}</label>
-    <div class="relative">
-      <Search size={16} class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary" />
-      <input
-        id="bias-search"
-        type="search"
-        bind:value={searchQuery}
-        placeholder={labels.searchPlaceholder}
-        class="w-full rounded-full border border-border bg-bg py-1.5 pl-9 pr-3 text-sm text-text placeholder:text-text-secondary focus:border-accent focus:outline-none"
-      />
-    </div>
-  </div>
+<FilterBar
+  {families}
+  {difficulties}
+  {activeFamilies}
+  {activeDifficulties}
+  {searchQuery}
+  onToggleFamily={toggleFamily}
+  onToggleDifficulty={toggleDifficulty}
+  onSearchChange={(value) => { searchQuery = value; }}
+  labels={{
+    family: labels.family,
+    difficulty: labels.difficulty,
+    search: labels.search,
+    searchPlaceholder: labels.searchPlaceholder,
+  }}
+/>
 
-  <div>
-    <span class="mb-2 block font-heading text-base font-semibold text-text">{labels.family}</span>
-    <div class="flex flex-wrap gap-2">
-      {#each families as { key, label }}
-        <button
-          class="family-pill cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors {activeFamilies.has(key)
-            ? 'family-pill-active border-transparent'
-            : 'border-border bg-bg text-text-secondary'}"
-          style={`--family-color: var(--family-${key})`}
-          onclick={() => toggleFamily(key)}
-        >
-          {label}
-        </button>
-      {/each}
-    </div>
-  </div>
-
-  <div>
-    <span class="mb-2 block font-heading text-base font-semibold text-text">{labels.difficulty}</span>
-    <div class="flex flex-wrap gap-2">
-      {#each difficulties as { key, label }}
-        <button
-          class="difficulty-pill cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors {activeDifficulties.has(key)
-            ? DIFFICULTY_COLORS[key] + ' border-current'
-            : 'border-border bg-bg text-text-secondary'}"
-          style={`--difficulty-color: var(--difficulty-${key})`}
-          onclick={() => toggleDifficulty(key)}
-        >
-          {label}
-        </button>
-      {/each}
-    </div>
-  </div>
-</div>
-
-<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
-  {#if filtered.length > 0}
-    <p class="text-sm text-text-secondary">{resultsLabel}</p>
-  {:else}
-    <span></span>
-  {/if}
-  {#if hasActiveFilters}
-    <button
-      type="button"
-      onclick={resetFilters}
-      class="flex cursor-pointer items-center gap-1.5 text-sm text-text-secondary transition-colors hover:text-accent"
-    >
-      <RotateCcw size={14} />
-      {labels.reset}
-    </button>
-  {/if}
-</div>
+<ResultsHeader
+  {resultsLabel}
+  hasResults={filtered.length > 0}
+  {hasActiveFilters}
+  onReset={resetFilters}
+  label={labels.reset}
+/>
 
 {#if filtered.length === 0}
   <p class="py-12 text-center text-text-secondary">{labels.noResults}</p>
@@ -197,24 +150,3 @@ const resetFilters = () => {
     {/each}
   </div>
 {/if}
-
-<style>
-  /* Active family pill: filled with family color (text adapts to theme via --family-contrast) */
-  .family-pill-active {
-    background-color: var(--family-color);
-    color: var(--family-contrast);
-  }
-
-  /* All family pills hover: border + text in family color, transparent background */
-  .family-pill:hover {
-    border-color: var(--family-color) !important;
-    color: var(--family-color);
-    background-color: transparent;
-  }
-
-  .difficulty-pill:hover {
-    border-color: var(--difficulty-color);
-    color: var(--difficulty-color);
-    background-color: transparent;
-  }
-</style>

--- a/src/components/BiasGrid.svelte
+++ b/src/components/BiasGrid.svelte
@@ -33,20 +33,25 @@ interface Props {
 	initialFamily?: string | null;
 	/** Pre-selected difficulty filter from query params (passed by Astro SSR). */
 	initialDifficulty?: string | null;
+	/** BCP 47 locale (e.g. "fr", "en") — used for Intl.PluralRules. */
+	locale: string;
 	labels: {
 		family: string;
 		difficulty: string;
 		search: string;
 		searchPlaceholder: string;
 		reset: string;
-		resultsCount: string;
-		resultsCountPlural: string;
+		/** Plural forms indexed by CLDR category (one, other, ...) with {count} placeholder. */
+		resultsCount: Record<string, string>;
 		noResults: string;
 	};
 }
 
-const { biases, families, difficulties, initialFamily, initialDifficulty, labels }: Props =
+const { biases, families, difficulties, initialFamily, initialDifficulty, locale, labels }: Props =
 	$props();
+
+// svelte-ignore state_referenced_locally — locale is a static SSR prop, won't change after mount
+const pluralRules = new Intl.PluralRules(locale);
 
 // svelte-ignore state_referenced_locally — props are static (from Astro), won't change after mount
 const familyKeys = families.map((family) => family.key);
@@ -93,13 +98,12 @@ const filtered = $derived.by(() => {
 	});
 });
 
-/** Formatted result count: picks singular/plural template and injects the number. */
-const resultsLabel = $derived(
-	(filtered.length <= 1 ? labels.resultsCount : labels.resultsCountPlural).replace(
-		"{count}",
-		String(filtered.length),
-	),
-);
+/** Formatted result count via Intl.PluralRules — selects the matching CLDR category. */
+const resultsLabel = $derived.by(() => {
+	const category = pluralRules.select(filtered.length);
+	const template = labels.resultsCount[category] ?? labels.resultsCount.other ?? "";
+	return template.replace("{count}", String(filtered.length));
+});
 
 /** True when any filter is narrowed (at least one family/difficulty disabled or search active). */
 const hasActiveFilters = $derived(

--- a/src/components/BiasGrid.svelte
+++ b/src/components/BiasGrid.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import autoAnimate from "@formkit/auto-animate";
+import { Search } from "lucide-svelte";
 import {
 	type BiasCardData,
 	DIFFICULTY_COLORS,
@@ -35,6 +36,8 @@ interface Props {
 	labels: {
 		family: string;
 		difficulty: string;
+		search: string;
+		searchPlaceholder: string;
 		noResults: string;
 	};
 }
@@ -60,6 +63,9 @@ let activeDifficulties = $state(
 		: new Set(difficultyKeys),
 );
 
+/** Text search query — matches against bias title (case-insensitive). */
+let searchQuery = $state("");
+
 const toggleFamily = (key: Family) => {
 	const next = new Set(activeFamilies);
 	if (next.has(key)) next.delete(key);
@@ -74,14 +80,32 @@ const toggleDifficulty = (key: Difficulty) => {
 	activeDifficulties = next;
 };
 
-const filtered = $derived(
-	biases.filter(
-		(bias) => activeFamilies.has(bias.family) && activeDifficulties.has(bias.difficulty),
-	),
-);
+const filtered = $derived.by(() => {
+	const normalizedQuery = searchQuery.trim().toLowerCase();
+	return biases.filter((bias) => {
+		if (!activeFamilies.has(bias.family)) return false;
+		if (!activeDifficulties.has(bias.difficulty)) return false;
+		if (normalizedQuery && !bias.title.toLowerCase().includes(normalizedQuery)) return false;
+		return true;
+	});
+});
 </script>
 
 <div class="sticky top-0 z-10 mb-6 flex flex-wrap gap-4 rounded-xl border border-accent/20 bg-accent-subtle p-3 shadow-sm sm:gap-6 sm:p-4">
+  <div class="w-full sm:w-auto sm:min-w-[220px] sm:flex-1">
+    <label for="bias-search" class="mb-2 block font-heading text-base font-semibold text-text">{labels.search}</label>
+    <div class="relative">
+      <Search size={16} class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary" />
+      <input
+        id="bias-search"
+        type="search"
+        bind:value={searchQuery}
+        placeholder={labels.searchPlaceholder}
+        class="w-full rounded-full border border-border bg-bg py-1.5 pl-9 pr-3 text-sm text-text placeholder:text-text-secondary focus:border-accent focus:outline-none"
+      />
+    </div>
+  </div>
+
   <div>
     <span class="mb-2 block font-heading text-base font-semibold text-text">{labels.family}</span>
     <div class="flex flex-wrap gap-2">

--- a/src/components/FilterBar.svelte
+++ b/src/components/FilterBar.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+import { Search } from "lucide-svelte";
+import { DIFFICULTY_COLORS, type Difficulty, type Family } from "@/lib/constants";
+
+interface FamilyOption {
+	key: Family;
+	label: string;
+}
+
+interface DifficultyOption {
+	key: Difficulty;
+	label: string;
+}
+
+interface Props {
+	families: FamilyOption[];
+	difficulties: DifficultyOption[];
+	activeFamilies: Set<Family>;
+	activeDifficulties: Set<Difficulty>;
+	searchQuery: string;
+	onToggleFamily: (key: Family) => void;
+	onToggleDifficulty: (key: Difficulty) => void;
+	onSearchChange: (value: string) => void;
+	labels: {
+		family: string;
+		difficulty: string;
+		search: string;
+		searchPlaceholder: string;
+	};
+}
+
+const {
+	families,
+	difficulties,
+	activeFamilies,
+	activeDifficulties,
+	searchQuery,
+	onToggleFamily,
+	onToggleDifficulty,
+	onSearchChange,
+	labels,
+}: Props = $props();
+</script>
+
+<div class="sticky top-0 z-10 mb-6 flex flex-wrap gap-4 rounded-xl border border-accent/20 bg-accent-subtle p-3 shadow-sm sm:gap-6 sm:p-4">
+  <div class="w-full sm:w-auto sm:min-w-[220px] sm:flex-1">
+    <label for="bias-search" class="mb-2 block font-heading text-base font-semibold text-text">{labels.search}</label>
+    <div class="relative">
+      <Search size={16} class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary" />
+      <input
+        id="bias-search"
+        type="search"
+        value={searchQuery}
+        oninput={(e) => onSearchChange(e.currentTarget.value)}
+        placeholder={labels.searchPlaceholder}
+        class="w-full rounded-full border border-border bg-bg py-1.5 pl-9 pr-3 text-sm text-text placeholder:text-text-secondary focus:border-accent focus:outline-none"
+      />
+    </div>
+  </div>
+
+  <div>
+    <span class="mb-2 block font-heading text-base font-semibold text-text">{labels.family}</span>
+    <div class="flex flex-wrap gap-2">
+      {#each families as { key, label }}
+        <button
+          class="family-pill cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors {activeFamilies.has(key)
+            ? 'family-pill-active border-transparent'
+            : 'border-border bg-bg text-text-secondary'}"
+          style={`--family-color: var(--family-${key})`}
+          onclick={() => onToggleFamily(key)}
+        >
+          {label}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div>
+    <span class="mb-2 block font-heading text-base font-semibold text-text">{labels.difficulty}</span>
+    <div class="flex flex-wrap gap-2">
+      {#each difficulties as { key, label }}
+        <button
+          class="difficulty-pill cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors {activeDifficulties.has(key)
+            ? DIFFICULTY_COLORS[key] + ' border-current'
+            : 'border-border bg-bg text-text-secondary'}"
+          style={`--difficulty-color: var(--difficulty-${key})`}
+          onclick={() => onToggleDifficulty(key)}
+        >
+          {label}
+        </button>
+      {/each}
+    </div>
+  </div>
+</div>
+
+<style>
+  /* Active family pill: filled with family color (text adapts to theme via --family-contrast) */
+  .family-pill-active {
+    background-color: var(--family-color);
+    color: var(--family-contrast);
+  }
+
+  /* All family pills hover: border + text in family color, transparent background */
+  .family-pill:hover {
+    border-color: var(--family-color) !important;
+    color: var(--family-color);
+    background-color: transparent;
+  }
+
+  .difficulty-pill:hover {
+    border-color: var(--difficulty-color);
+    color: var(--difficulty-color);
+    background-color: transparent;
+  }
+</style>

--- a/src/components/FilterBar.svelte
+++ b/src/components/FilterBar.svelte
@@ -63,8 +63,8 @@ const {
     <div class="flex flex-wrap gap-2">
       {#each families as { key, label }}
         <button
-          class="family-pill cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors {activeFamilies.has(key)
-            ? 'family-pill-active border-transparent'
+          class="cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors hover:!border-[var(--family-color)] hover:bg-transparent hover:text-[var(--family-color)] {activeFamilies.has(key)
+            ? 'border-transparent bg-[var(--family-color)] text-[var(--family-contrast)]'
             : 'border-border bg-bg text-text-secondary'}"
           style={`--family-color: var(--family-${key})`}
           onclick={() => onToggleFamily(key)}
@@ -80,7 +80,7 @@ const {
     <div class="flex flex-wrap gap-2">
       {#each difficulties as { key, label }}
         <button
-          class="difficulty-pill cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors {activeDifficulties.has(key)
+          class="cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors hover:border-[var(--difficulty-color)] hover:bg-transparent hover:text-[var(--difficulty-color)] {activeDifficulties.has(key)
             ? DIFFICULTY_COLORS[key] + ' border-current'
             : 'border-border bg-bg text-text-secondary'}"
           style={`--difficulty-color: var(--difficulty-${key})`}
@@ -92,24 +92,3 @@ const {
     </div>
   </div>
 </div>
-
-<style>
-  /* Active family pill: filled with family color (text adapts to theme via --family-contrast) */
-  .family-pill-active {
-    background-color: var(--family-color);
-    color: var(--family-contrast);
-  }
-
-  /* All family pills hover: border + text in family color, transparent background */
-  .family-pill:hover {
-    border-color: var(--family-color) !important;
-    color: var(--family-color);
-    background-color: transparent;
-  }
-
-  .difficulty-pill:hover {
-    border-color: var(--difficulty-color);
-    color: var(--difficulty-color);
-    background-color: transparent;
-  }
-</style>

--- a/src/components/ResultsHeader.svelte
+++ b/src/components/ResultsHeader.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { RotateCcw } from "lucide-svelte";
+
+interface Props {
+	/** Pre-formatted results label (e.g. "12 biais trouvés"). Hidden when count is 0. */
+	resultsLabel: string;
+	/** Whether to show the count — set to false when there are no results. */
+	hasResults: boolean;
+	/** Whether the reset button should be visible (i.e. at least one filter is narrowed). */
+	hasActiveFilters: boolean;
+	onReset: () => void;
+	label: string;
+}
+
+const { resultsLabel, hasResults, hasActiveFilters, onReset, label }: Props = $props();
+</script>
+
+<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+  {#if hasResults}
+    <p class="text-sm text-text-secondary">{resultsLabel}</p>
+  {:else}
+    <span></span>
+  {/if}
+  {#if hasActiveFilters}
+    <button
+      type="button"
+      onclick={onReset}
+      class="flex cursor-pointer items-center gap-1.5 text-sm text-text-secondary transition-colors hover:text-accent"
+    >
+      <RotateCcw size={14} />
+      {label}
+    </button>
+  {/if}
+</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -52,6 +52,8 @@
 	"home.view.flat": "All",
 	"home.filter.family": "Family",
 	"home.filter.difficulty": "Difficulty",
+	"home.filter.search": "Search a bias",
+	"home.filter.search-placeholder": "Bias name...",
 	"error.404.back": "Back to home",
 	"error.404.messages": [
 		"Blind spot bias — you were convinced this page existed.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -56,6 +56,7 @@
 	"home.filter.difficulty": "Difficulty",
 	"home.filter.search": "Search a bias",
 	"home.filter.search-placeholder": "Bias name...",
+	"home.filter.reset": "Reset",
 	"error.404.back": "Back to home",
 	"error.404.messages": [
 		"Blind spot bias — you were convinced this page existed.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -48,8 +48,10 @@
 	"about.github": "Contribute on GitHub",
 	"home.empty": "Coming soon",
 	"home.no-results": "No biases match",
-	"home.results-count": "{count} bias found",
-	"home.results-count-plural": "{count} biases found",
+	"home.results-count": {
+		"one": "{count} bias found",
+		"other": "{count} biases found"
+	},
 	"home.view.grouped": "By family",
 	"home.view.flat": "All",
 	"home.filter.family": "Family",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -48,6 +48,8 @@
 	"about.github": "Contribute on GitHub",
 	"home.empty": "Coming soon",
 	"home.no-results": "No biases match",
+	"home.results-count": "{count} bias found",
+	"home.results-count-plural": "{count} biases found",
 	"home.view.grouped": "By family",
 	"home.view.flat": "All",
 	"home.filter.family": "Family",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -48,8 +48,10 @@
 	"about.github": "Contribuer sur GitHub",
 	"home.empty": "Bientôt disponible",
 	"home.no-results": "Aucun biais ne correspond",
-	"home.results-count": "{count} biais trouvé",
-	"home.results-count-plural": "{count} biais trouvés",
+	"home.results-count": {
+		"one": "{count} biais trouvé",
+		"other": "{count} biais trouvés"
+	},
 	"home.view.grouped": "Par famille",
 	"home.view.flat": "Tous",
 	"home.filter.family": "Famille",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -52,6 +52,8 @@
 	"home.view.flat": "Tous",
 	"home.filter.family": "Famille",
 	"home.filter.difficulty": "Difficulté",
+	"home.filter.search": "Rechercher un biais",
+	"home.filter.search-placeholder": "Nom du biais...",
 	"error.404.back": "Retour à l'accueil",
 	"error.404.messages": [
 		"Biais de l'angle mort — vous étiez convaincu que cette page existait.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -48,6 +48,8 @@
 	"about.github": "Contribuer sur GitHub",
 	"home.empty": "Bientôt disponible",
 	"home.no-results": "Aucun biais ne correspond",
+	"home.results-count": "{count} biais trouvé",
+	"home.results-count-plural": "{count} biais trouvés",
 	"home.view.grouped": "Par famille",
 	"home.view.flat": "Tous",
 	"home.filter.family": "Famille",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -56,6 +56,7 @@
 	"home.filter.difficulty": "Difficulté",
 	"home.filter.search": "Rechercher un biais",
 	"home.filter.search-placeholder": "Nom du biais...",
+	"home.filter.reset": "Réinitialiser",
 	"error.404.back": "Retour à l'accueil",
 	"error.404.messages": [
 		"Biais de l'angle mort — vous étiez convaincu que cette page existait.",

--- a/src/i18n/i18n.test.ts
+++ b/src/i18n/i18n.test.ts
@@ -7,6 +7,8 @@ import {
 	isLocale,
 	SUPPORTED_LOCALES,
 	t,
+	tn,
+	tPlural,
 	tRaw,
 } from "./i18n";
 
@@ -63,6 +65,33 @@ describe("tRaw", () => {
 
 	it("returns undefined for missing keys", () => {
 		expect(tRaw("fr", "nonexistent.key")).toBeUndefined();
+	});
+});
+
+describe("tPlural", () => {
+	it("returns the plural forms object", () => {
+		const forms = tPlural("fr", "home.results-count");
+		expect(forms).toHaveProperty("one");
+		expect(forms).toHaveProperty("other");
+	});
+
+	it("returns an empty object for non-plural keys", () => {
+		expect(tPlural("fr", "site.title")).toEqual({});
+	});
+
+	it("returns an empty object for missing keys", () => {
+		expect(tPlural("fr", "nonexistent.key")).toEqual({});
+	});
+});
+
+describe("tn", () => {
+	it("replaces the {count} placeholder with the number", () => {
+		expect(tn("fr", "home.results-count", 1)).toContain("1");
+		expect(tn("fr", "home.results-count", 42)).toContain("42");
+	});
+
+	it("returns the key itself when the pluralized key is missing", () => {
+		expect(tn("fr", "nonexistent.key", 1)).toBe("nonexistent.key");
 	});
 });
 

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -43,6 +43,46 @@ export const tRaw = (locale: Locale, key: string): unknown => {
 	return dict[key];
 };
 
+/** Cached Intl.PluralRules instances per locale (created lazily on first use). */
+const pluralRulesCache = new Map<Locale, Intl.PluralRules>();
+
+const getPluralRules = (locale: Locale): Intl.PluralRules => {
+	const cached = pluralRulesCache.get(locale);
+	if (cached) return cached;
+	const rules = new Intl.PluralRules(locale);
+	pluralRulesCache.set(locale, rules);
+	return rules;
+};
+
+/** Runtime guard: checks that a value is an object mapping string keys to strings. */
+const isPluralForms = (value: unknown): value is Record<string, string> => {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	return Object.values(value).every((v) => typeof v === "string");
+};
+
+/**
+ * Returns the plural-forms object for `key` (CLDR categories → template strings).
+ * Returns an empty object if the key is missing or malformed, so the caller
+ * degrades gracefully rather than crashing.
+ */
+export const tPlural = (locale: Locale, key: string): Record<string, string> => {
+	const raw = tRaw(locale, key);
+	return isPluralForms(raw) ? raw : {};
+};
+
+/**
+ * Translates a pluralized key using Intl.PluralRules.
+ * The JSON value must be an object with keys matching CLDR plural categories
+ * (e.g. { "one": "...", "other": "..." }). Replaces `{count}` with the number.
+ * Falls back to the "other" form if the matching category is missing.
+ */
+export const tn = (locale: Locale, key: string, count: number): string => {
+	const forms = tPlural(locale, key);
+	const category = getPluralRules(locale).select(count);
+	const template = forms[category] ?? forms.other ?? key;
+	return template.replace("{count}", String(count));
+};
+
 /** Extracts the locale from the first URL path segment. Defaults to `fr`. */
 export const getLocaleFromUrl = (url: URL): Locale => {
 	const segment = url.pathname.split("/")[1];

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -6,7 +6,7 @@
  */
 import BiasCard from "@/components/BiasCard.svelte";
 import BiasGrid from "@/components/BiasGrid.svelte";
-import { t } from "@/i18n/i18n";
+import { t, tPlural } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBiasesForLocale } from "@/lib/biases";
 import { DIFFICULTIES, FAMILIES } from "@/lib/constants";
@@ -109,14 +109,14 @@ const hasFilters = filterFamily !== null || filterDifficulty !== null;
         difficulties={difficultyOptions}
         initialFamily={filterFamily}
         initialDifficulty={filterDifficulty}
+        locale={locale}
         labels={{
           family: t(locale, "home.filter.family"),
           difficulty: t(locale, "home.filter.difficulty"),
           search: t(locale, "home.filter.search"),
           searchPlaceholder: t(locale, "home.filter.search-placeholder"),
           reset: t(locale, "home.filter.reset"),
-          resultsCount: t(locale, "home.results-count"),
-          resultsCountPlural: t(locale, "home.results-count-plural"),
+          resultsCount: tPlural(locale, "home.results-count"),
           noResults: t(locale, "home.no-results"),
         }}
         client:visible

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -114,6 +114,8 @@ const hasFilters = filterFamily !== null || filterDifficulty !== null;
           difficulty: t(locale, "home.filter.difficulty"),
           search: t(locale, "home.filter.search"),
           searchPlaceholder: t(locale, "home.filter.search-placeholder"),
+          resultsCount: t(locale, "home.results-count"),
+          resultsCountPlural: t(locale, "home.results-count-plural"),
           noResults: t(locale, "home.no-results"),
         }}
         client:visible

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -114,6 +114,7 @@ const hasFilters = filterFamily !== null || filterDifficulty !== null;
           difficulty: t(locale, "home.filter.difficulty"),
           search: t(locale, "home.filter.search"),
           searchPlaceholder: t(locale, "home.filter.search-placeholder"),
+          reset: t(locale, "home.filter.reset"),
           resultsCount: t(locale, "home.results-count"),
           resultsCountPlural: t(locale, "home.results-count-plural"),
           noResults: t(locale, "home.no-results"),

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -112,6 +112,8 @@ const hasFilters = filterFamily !== null || filterDifficulty !== null;
         labels={{
           family: t(locale, "home.filter.family"),
           difficulty: t(locale, "home.filter.difficulty"),
+          search: t(locale, "home.filter.search"),
+          searchPlaceholder: t(locale, "home.filter.search-placeholder"),
           noResults: t(locale, "home.no-results"),
         }}
         client:visible


### PR DESCRIPTION
## Summary

- **Text search** — search biases by title (case-insensitive), combined with existing filters
- **Results counter** — "X biases found" displayed above the grid
- **Reset filters button** — visible when any filter is narrowed, restores default state

## Responsive

- Search field takes full width on mobile, shares row with filter pills on desktop
- Counter + reset button on a single flex row with wrap-around on narrow screens

## Test plan

- [ ] Type in search — grid filters live by title match
- [ ] Combine search with family/difficulty pills — all filters apply together
- [ ] Counter updates live, singular/plural correct
- [ ] Reset button hidden by default, appears when a filter is narrowed
- [ ] Reset restores all filters and clears search
- [ ] Mobile layout looks correct