### PR TITLE
refactor: DRY localized routes with buildAltLangHrefs helper

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -68,6 +68,22 @@ for (const locale of SUPPORTED_LOCALES) {
 }
 
 /**
+ * Builds altLangHrefs for a page identified by its slug key.
+ * Returns a record mapping each non-current locale to its localized URL.
+ * E.g. buildAltLangHrefs("fr", "leaderboard") → { en: "/en/leaderboard" }
+ */
+export const buildAltLangHrefs = (
+	currentLocale: Locale,
+	slugKey: SlugKey,
+): Record<string, string> =>
+	Object.fromEntries(
+		SUPPORTED_LOCALES.filter((l) => l !== currentLocale).map((l) => [
+			l,
+			`/${l}/${getSlug(slugKey, l)}`,
+		]),
+	);
+
+/**
  * Validates a route `lang` param and returns the locale.
  * Returns `null` if the param is missing or not a supported locale,
  * along with a fallback redirect URL based on Accept-Language.

--- a/src/pages/[lang]/a-propos.astro
+++ b/src/pages/[lang]/a-propos.astro
@@ -5,14 +5,13 @@ import type { GetStaticPaths } from "astro";
 
 export const getStaticPaths: GetStaticPaths = () => [{ params: { lang: "fr" } }];
 
-/** About page (French route: /fr/a-propos). */
 import AboutPage from "@/components/AboutPage.astro";
+import { buildAltLangHrefs } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { m } from "@/paraglide/messages";
 
 const { locale } = Astro.locals;
-
-Astro.locals.altLangHrefs = { en: "/en/about" };
+Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "about");
 
 const pageTitle = m.about_title();
 ---

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -5,14 +5,13 @@ import type { GetStaticPaths } from "astro";
 
 export const getStaticPaths: GetStaticPaths = () => [{ params: { lang: "en" } }];
 
-/** About page (English route: /en/about). */
 import AboutPage from "@/components/AboutPage.astro";
+import { buildAltLangHrefs } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { m } from "@/paraglide/messages";
 
 const { locale } = Astro.locals;
-
-Astro.locals.altLangHrefs = { fr: "/fr/a-propos" };
+Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "about");
 
 const pageTitle = m.about_title();
 ---

--- a/src/pages/[lang]/biais/[slug].astro
+++ b/src/pages/[lang]/biais/[slug].astro
@@ -3,11 +3,11 @@ export const prerender = true;
 
 import type { GetStaticPaths } from "astro";
 import BiasPage from "@/components/BiasPage.astro";
+import { getSlug, SUPPORTED_LOCALES } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBiasesForLocale } from "@/lib/biases";
 import type { Family } from "@/lib/constants";
 import { m } from "@/paraglide/messages";
-import { locales } from "@/paraglide/runtime";
 
 export const getStaticPaths: GetStaticPaths = async () => {
 	const { localized } = await getBiasesForLocale("fr");
@@ -34,17 +34,13 @@ if (!entry) {
  */
 const biasFolder = entry.filePath?.replace(`/${locale}.md`, "").split("/").pop() ?? "";
 Astro.locals.altLangHrefs = Object.fromEntries(
-	locales
-		.filter((otherLocale) => otherLocale !== locale)
+	SUPPORTED_LOCALES.filter((otherLocale) => otherLocale !== locale)
 		.map((otherLocale) => {
 			const alternate = allBiases.find((bias) =>
 				bias.filePath?.endsWith(`${biasFolder}/${otherLocale}.md`),
 			);
 			return alternate
-				? [
-						otherLocale,
-						`/${otherLocale}/${m.slug_bias({}, { locale: otherLocale })}/${alternate.data.slug}`,
-					]
+				? [otherLocale, `/${otherLocale}/${getSlug("bias", otherLocale)}/${alternate.data.slug}`]
 				: [];
 		})
 		.filter((pair) => pair.length > 0),

--- a/src/pages/[lang]/bias/[slug].astro
+++ b/src/pages/[lang]/bias/[slug].astro
@@ -3,11 +3,11 @@ export const prerender = true;
 
 import type { GetStaticPaths } from "astro";
 import BiasPage from "@/components/BiasPage.astro";
+import { getSlug, SUPPORTED_LOCALES } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBiasesForLocale } from "@/lib/biases";
 import type { Family } from "@/lib/constants";
 import { m } from "@/paraglide/messages";
-import { locales } from "@/paraglide/runtime";
 
 export const getStaticPaths: GetStaticPaths = async () => {
 	const { localized } = await getBiasesForLocale("en");
@@ -34,17 +34,13 @@ if (!entry) {
  */
 const biasFolder = entry.filePath?.replace(`/${locale}.md`, "").split("/").pop() ?? "";
 Astro.locals.altLangHrefs = Object.fromEntries(
-	locales
-		.filter((otherLocale) => otherLocale !== locale)
+	SUPPORTED_LOCALES.filter((otherLocale) => otherLocale !== locale)
 		.map((otherLocale) => {
 			const alternate = allBiases.find((bias) =>
 				bias.filePath?.endsWith(`${biasFolder}/${otherLocale}.md`),
 			);
 			return alternate
-				? [
-						otherLocale,
-						`/${otherLocale}/${m.slug_bias({}, { locale: otherLocale })}/${alternate.data.slug}`,
-					]
+				? [otherLocale, `/${otherLocale}/${getSlug("bias", otherLocale)}/${alternate.data.slug}`]
 				: [];
 		})
 		.filter((pair) => pair.length > 0),

--- a/src/pages/[lang]/classement.astro
+++ b/src/pages/[lang]/classement.astro
@@ -1,12 +1,11 @@
 ---
-/** Leaderboard page (French route: /fr/classement). */
 import Leaderboard from "@/components/Leaderboard.svelte";
+import { buildAltLangHrefs } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { m } from "@/paraglide/messages";
 
 const { locale } = Astro.locals;
-
-Astro.locals.altLangHrefs = { en: "/en/leaderboard" };
+Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "leaderboard");
 
 const pageTitle = m.leaderboard_title();
 const labels = {

--- a/src/pages/[lang]/leaderboard.astro
+++ b/src/pages/[lang]/leaderboard.astro
@@ -1,12 +1,11 @@
 ---
-/** Leaderboard page (English route: /en/leaderboard). */
 import LeaderboardComponent from "@/components/Leaderboard.svelte";
+import { buildAltLangHrefs } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { m } from "@/paraglide/messages";
 
 const { locale } = Astro.locals;
-
-Astro.locals.altLangHrefs = { fr: "/fr/classement" };
+Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "leaderboard");
 
 const pageTitle = m.leaderboard_title();
 const labels = {

--- a/src/pages/[lang]/profil.astro
+++ b/src/pages/[lang]/profil.astro
@@ -1,5 +1,6 @@
 ---
 import ProfilePage from "@/components/interactive/ProfilePage.svelte";
+import { buildAltLangHrefs } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBiasesForLocale } from "@/lib/biases";
 import { getProfileLabels } from "@/lib/labels";
@@ -10,7 +11,7 @@ const { locale } = Astro.locals;
 const { localized: biases } = await getBiasesForLocale(locale);
 const title = `${m.profile_title()} — ${m.site_title()}`;
 
-Astro.locals.altLangHrefs = { en: "/en/profile" };
+Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "profile");
 ---
 
 <BaseLayout title={title} description={m.site_description()} lang={locale}>

--- a/src/pages/[lang]/profile.astro
+++ b/src/pages/[lang]/profile.astro
@@ -1,16 +1,16 @@
 ---
 import ProfilePage from "@/components/interactive/ProfilePage.svelte";
+import { buildAltLangHrefs } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBiasesForLocale } from "@/lib/biases";
 import { getProfileLabels } from "@/lib/labels";
 import { m } from "@/paraglide/messages";
 
 const { locale } = Astro.locals;
+Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "profile");
 
 const { localized: biases } = await getBiasesForLocale(locale);
 const title = `${m.profile_title()} — ${m.site_title()}`;
-
-Astro.locals.altLangHrefs = { fr: "/fr/profil" };
 ---
 
 <BaseLayout title={title} description={m.site_description()} lang={locale}>


### PR DESCRIPTION
## Summary

Reduce duplication in the 8 localized route files (4 pairs: about, leaderboard, profile, bias).

- **New helper** \`buildAltLangHrefs(locale, slugKey)\` in \`i18n.ts\` — generates alt-language URLs dynamically from the slug key, replacing hardcoded URLs
- **Bias routes** use \`getSlug()\` + \`SUPPORTED_LOCALES\` instead of importing Paraglide runtime \`locales\`
- Route pairs are now identical except for \`getStaticPaths\` locale and file name

## Test plan

- [ ] Language switcher works on all pages (about, leaderboard, profile, bias)
- [ ] Alt-lang hrefs are correct in both directions (FR→EN, EN→FR)
- [ ] All tests pass (\`pnpm vitest run\`)
- [ ] Build succeeds