### PR TITLE
feat: bias page reading & navigation improvements

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -32,6 +32,7 @@
 	"sources_papers": "Scientific papers",
 	"sources_videos": "Videos",
 	"bias_related": "Related biases",
+	"bias_toc_title": "Table of contents",
 	"slug_leaderboard": "leaderboard",
 	"slug_about": "about",
 	"slug_bias": "bias",

--- a/project.inlang/messages/fr.json
+++ b/project.inlang/messages/fr.json
@@ -32,6 +32,7 @@
 	"sources_papers": "Articles scientifiques",
 	"sources_videos": "Vidéos",
 	"bias_related": "Biais liés",
+	"bias_toc_title": "Sommaire",
 	"slug_leaderboard": "classement",
 	"slug_about": "a-propos",
 	"slug_bias": "biais",

--- a/src/components/BackToTop.svelte
+++ b/src/components/BackToTop.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { ChevronUp } from "lucide-svelte";
+import { onMount } from "svelte";
+
+let visible = $state(false);
+
+onMount(() => {
+	const onScroll = () => {
+		visible = window.scrollY > 400;
+	};
+
+	window.addEventListener("scroll", onScroll, { passive: true });
+	onScroll();
+
+	return () => window.removeEventListener("scroll", onScroll);
+});
+
+const scrollToTop = () => {
+	window.scrollTo({ top: 0, behavior: "smooth" });
+};
+</script>
+
+<button
+	onclick={scrollToTop}
+	type="button"
+	class="fixed bottom-6 right-6 z-40 flex cursor-pointer items-center justify-center rounded-full border border-border bg-surface p-3 shadow-lg transition-all hover:bg-accent hover:text-white {visible
+		? 'opacity-100 translate-y-0'
+		: 'pointer-events-none opacity-0 translate-y-4'}"
+	aria-label="Back to top"
+	aria-hidden={!visible}
+	tabindex={visible ? 0 : -1}
+>
+	<ChevronUp size={20} />
+</button>

--- a/src/components/BiasPage.astro
+++ b/src/components/BiasPage.astro
@@ -5,9 +5,12 @@ import type { CollectionEntry } from "astro:content";
  * interactive situation/quiz, sources, and related biases.
  */
 import { render } from "astro:content";
+import BackToTop from "@/components/BackToTop.svelte";
 import BiasRelatedSection from "@/components/BiasRelatedSection.astro";
 import BiasSourcesSection from "@/components/BiasSourcesSection.astro";
+import Breadcrumb from "@/components/Breadcrumb.astro";
 import BiasInteractive from "@/components/interactive/BiasInteractive.svelte";
+import TableOfContents from "@/components/TableOfContents.astro";
 import type { Locale } from "@/i18n/i18n";
 import { DIFFICULTY_COLORS, type Difficulty, type Family } from "@/lib/constants";
 import { getBiasInteractiveLabels } from "@/lib/labels";
@@ -33,12 +36,14 @@ interface Props {
 
 const { entry, locale } = Astro.props;
 const { data } = entry;
-const { Content } = await render(entry);
+const { Content, headings } = await render(entry);
 
 const showOriginalName = data.originalName !== data.title;
 ---
 
 <article class="mx-auto max-w-3xl">
+  <Breadcrumb locale={locale} family={data.family} title={data.title} />
+
   <!-- Header: title, original name, badges -->
   <header class="mb-8">
     <h1 class="text-3xl font-bold">{data.title}</h1>
@@ -67,6 +72,8 @@ const showOriginalName = data.originalName !== data.title;
     </div>
   </header>
 
+  <TableOfContents headings={headings} />
+
   <!-- Markdown content with typography styles (invert colors in dark mode) -->
   <div class="prose prose-slate max-w-none dark:prose-invert">
     <Content />
@@ -92,6 +99,8 @@ const showOriginalName = data.originalName !== data.title;
   <!-- Related biases -->
   <BiasRelatedSection locale={locale} relatedBiases={data.relatedBiases} />
 </article>
+
+<BackToTop client:load />
 
 <style>
   .badge-family:hover {

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,32 @@
+---
+/**
+ * Breadcrumb navigation: Home > Family > Current page title.
+ */
+import type { Family } from "@/lib/constants";
+import { m } from "@/paraglide/messages";
+
+const familyLabel: Record<Family, () => string> = {
+	"too-much-information": m.bias_family_too_much_information,
+	"not-enough-meaning": m.bias_family_not_enough_meaning,
+	"need-to-act-fast": m.bias_family_need_to_act_fast,
+	"what-to-remember": m.bias_family_what_to_remember,
+};
+
+interface Props {
+	locale: string;
+	family: Family;
+	title: string;
+}
+
+const { locale, family, title } = Astro.props;
+---
+
+<nav aria-label="Breadcrumb" class="mb-4 text-sm text-text-secondary">
+  <ol class="flex flex-wrap items-center gap-1" role="list">
+    <li><a href={`/${locale}/`} class="no-underline hover:underline">{m.nav_home()}</a></li>
+    <li class="before:mx-1 before:content-['/']">
+      <a href={`/${locale}/?family=${family}`} class="no-underline hover:underline">{familyLabel[family]()}</a>
+    </li>
+    <li class="before:mx-1 before:content-['/'] text-text">{title}</li>
+  </ol>
+</nav>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * Table of contents for bias pages.
+ * Generated from markdown headings + hardcoded interactive sections (situation/quiz).
+ */
+import { m } from "@/paraglide/messages";
+import BookOpenIcon from "~icons/lucide/book-open";
+import CircleHelpIcon from "~icons/lucide/circle-help";
+import HashIcon from "~icons/lucide/hash";
+import LightbulbIcon from "~icons/lucide/lightbulb";
+import ListIcon from "~icons/lucide/list";
+import CogIcon from "~icons/lucide/settings";
+import SparklesIcon from "~icons/lucide/sparkles";
+import TextIcon from "~icons/lucide/text";
+
+interface Heading {
+	depth: number;
+	slug: string;
+	text: string;
+}
+
+interface Props {
+	headings: Heading[];
+}
+
+const { headings } = Astro.props;
+
+/** Map icon → heading slugs for the TOC. */
+const iconBySlugs = new Map<typeof BookOpenIcon, string[]>([
+	[BookOpenIcon, ["définition", "definition"]],
+	[CogIcon, ["mécanisme", "mechanism"]],
+	[TextIcon, ["exemples", "examples"]],
+	[SparklesIcon, ["le-saviez-vous-", "did-you-know-"]],
+]);
+
+/** Reverse lookup: slug → icon. */
+const headingIcons = new Map<string, typeof BookOpenIcon>();
+for (const [icon, slugs] of iconBySlugs) {
+	for (const slug of slugs) headingIcons.set(slug, icon);
+}
+
+/** Pre-resolve icons for each heading. */
+const entries = headings
+	.filter((h) => h.depth <= 3)
+	.map((h) => ({
+		...h,
+		Icon: headingIcons.get(h.slug) ?? HashIcon,
+	}));
+---
+
+<nav aria-label="Table of contents" class="mb-8 rounded-lg border border-border bg-surface p-4 sm:p-5">
+  <p class="mb-3 flex items-center gap-2 font-heading text-base font-semibold text-text">
+    <ListIcon class="inline-block h-5 w-5" aria-hidden="true" />
+    {m.bias_toc_title()}
+  </p>
+  <ol class="list-none space-y-1.5" role="list">
+    {entries.map(({ slug, text, Icon }) => (
+      <li>
+        <a href={`#${slug}`} class="flex items-center gap-1.5 text-sm text-text-secondary no-underline hover:text-accent">
+          <Icon class="inline-block h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          {text}
+        </a>
+      </li>
+    ))}
+    <li>
+      <a href="#situation" class="flex items-center gap-1.5 text-sm text-text-secondary no-underline hover:text-accent">
+        <LightbulbIcon class="inline-block h-3.5 w-3.5" aria-hidden="true" />
+        {m.situation_title()}
+      </a>
+    </li>
+    <li>
+      <a href="#quiz" class="flex items-center gap-1.5 text-sm text-text-secondary no-underline hover:text-accent">
+        <CircleHelpIcon class="inline-block h-3.5 w-3.5" aria-hidden="true" />
+        {m.quiz_title()}
+      </a>
+    </li>
+  </ol>
+</nav>

--- a/src/components/interactive/BiasInteractive.svelte
+++ b/src/components/interactive/BiasInteractive.svelte
@@ -63,14 +63,14 @@ const handleRecoveryDismiss = () => {
 </script>
 
 {#if situation}
-	<section class="mt-12">
+	<section class="mt-12" id="situation">
 		<h2 class="mb-4 text-2xl font-bold">{labels.situationTitle}</h2>
 		<Situation data={situation} onComplete={handleSituationComplete} />
 	</section>
 {/if}
 
 {#if quiz}
-	<section class="mt-12">
+	<section class="mt-12" id="quiz">
 		<h2 class="mb-4 text-2xl font-bold">{labels.quizTitle}</h2>
 		<Quiz data={quiz} labels={labels.quiz} onComplete={handleQuizComplete} />
 	</section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,7 +10,7 @@
 	--color-text-secondary: #64748b;
 	--color-surface: #ffffff;
 	--color-border: #e2e8f0;
-	--color-accent: #0d9488;
+	--color-accent: #0f766e;
 	--color-accent-subtle: #e6f5f3;
 
 	--font-body: "Space Grotesk Variable", system-ui, sans-serif;


### PR DESCRIPTION
## Summary

Closes #25.

- **Breadcrumb** — Home > Family > Bias name, with links to homepage family filter
- **Reading progress bar** — thin accent-colored bar at the top that fills as you scroll
- **Table of contents** — generated from markdown `##` headings, displayed before content
- **Back to top** — floating button that appears after 400px scroll, smooth scrolls to top

## Test plan

- [ ] Breadcrumb shows correct family name and links to filtered homepage
- [ ] Progress bar fills from 0 to 100% as you scroll through a bias page
- [ ] TOC lists all `##` headings and clicking links scrolls to the section
- [ ] Back-to-top button appears when scrolling down and smooth-scrolls to top
- [ ] All 4 features work in both light and dark mode
- [ ] Responsive on mobile