### PR TITLE
refactor: use Astro.locals.locale instead of props

### DIFF
--- a/src/components/BiasPage.astro
+++ b/src/components/BiasPage.astro
@@ -11,7 +11,6 @@ import BiasSourcesSection from "@/components/BiasSourcesSection.astro";
 import Breadcrumb from "@/components/Breadcrumb.astro";
 import BiasInteractive from "@/components/interactive/BiasInteractive.svelte";
 import TableOfContents from "@/components/TableOfContents.astro";
-import type { Locale } from "@/i18n/i18n";
 import { DIFFICULTY_COLORS, type Difficulty, type Family } from "@/lib/constants";
 import { getBiasInteractiveLabels } from "@/lib/labels";
 import { m } from "@/paraglide/messages";
@@ -31,10 +30,10 @@ const difficultyLabel: Record<Difficulty, () => string> = {
 
 interface Props {
 	entry: CollectionEntry<"biases">;
-	locale: Locale;
 }
 
-const { entry, locale } = Astro.props;
+const { entry } = Astro.props;
+const { locale } = Astro.locals;
 const { data } = entry;
 const { Content, headings } = await render(entry);
 
@@ -42,7 +41,7 @@ const showOriginalName = data.originalName !== data.title;
 ---
 
 <article class="mx-auto max-w-3xl">
-  <Breadcrumb locale={locale} family={data.family} title={data.title} />
+  <Breadcrumb family={data.family} title={data.title} />
 
   <!-- Header: title, original name, badges -->
   <header class="mb-8">
@@ -97,7 +96,7 @@ const showOriginalName = data.originalName !== data.title;
   />
 
   <!-- Related biases -->
-  <BiasRelatedSection locale={locale} relatedBiases={data.relatedBiases} />
+  <BiasRelatedSection relatedBiases={data.relatedBiases} />
 </article>
 
 <BackToTop client:load />

--- a/src/components/BiasRelatedSection.astro
+++ b/src/components/BiasRelatedSection.astro
@@ -3,16 +3,15 @@
  * Displays related biases as links. Biases that exist in the content
  * collection are clickable links; others are shown as grayed-out text.
  */
-import type { Locale } from "@/i18n/i18n";
 import { getBiasesForLocale } from "@/lib/biases";
 import { m } from "@/paraglide/messages";
 
 interface Props {
-	locale: Locale;
 	relatedBiases: string[];
 }
 
-const { locale, relatedBiases } = Astro.props;
+const { relatedBiases } = Astro.props;
+const { locale } = Astro.locals;
 
 if (relatedBiases.length === 0) return;
 

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -13,12 +13,12 @@ const familyLabel: Record<Family, () => string> = {
 };
 
 interface Props {
-	locale: string;
 	family: Family;
 	title: string;
 }
 
-const { locale, family, title } = Astro.props;
+const { family, title } = Astro.props;
+const { locale } = Astro.locals;
 ---
 
 <nav aria-label="Breadcrumb" class="mb-4 text-sm text-text-secondary">

--- a/src/pages/[lang]/biais/[slug].astro
+++ b/src/pages/[lang]/biais/[slug].astro
@@ -59,5 +59,5 @@ const description = `${entry.data.title} — ${familyLabel[entry.data.family]()}
 ---
 
 <BaseLayout title={title} description={description} lang={locale}>
-	<BiasPage entry={entry} locale={locale} />
+	<BiasPage entry={entry} />
 </BaseLayout>

--- a/src/pages/[lang]/bias/[slug].astro
+++ b/src/pages/[lang]/bias/[slug].astro
@@ -59,5 +59,5 @@ const description = `${entry.data.title} — ${familyLabel[entry.data.family]()}
 ---
 
 <BaseLayout title={title} description={description} lang={locale}>
-	<BiasPage entry={entry} locale={locale} />
+	<BiasPage entry={entry} />
 </BaseLayout>


### PR DESCRIPTION
## Summary

Remove `locale` prop drilling from Astro components that can read it directly from `Astro.locals.locale` (set by the middleware).

**Components updated:**
- `BiasPage.astro` — no longer receives `locale` prop
- `Breadcrumb.astro` — reads locale from locals
- `BiasRelatedSection.astro` — reads locale from locals

**Callers updated:**
- `biais/[slug].astro` and `bias/[slug].astro` — stop passing `locale` to BiasPage

## Test plan

- [ ] Bias pages render correctly in both FR and EN
- [ ] Breadcrumb shows correct locale-prefixed links
- [ ] Related biases links use correct locale prefix
- [ ] Language switcher still works on bias pages