### PR TITLE
feat: make completed biases clickable with translated titles

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -104,6 +104,7 @@
 	"profile_progression_biases": "{count}/{total} biases completed",
 	"profile_total_score": "Total score",
 	"profile_completed_biases": "Completed biases",
+	"profile_bias_column": "Bias",
 	"profile_score_column": "Score",
 	"profile_no_scores": "No biases completed yet",
 	"nav_profile": "Profile",

--- a/project.inlang/messages/fr.json
+++ b/project.inlang/messages/fr.json
@@ -104,6 +104,7 @@
 	"profile_progression_biases": "{count}/{total} biais complétés",
 	"profile_total_score": "Score total",
 	"profile_completed_biases": "Biais complétés",
+	"profile_bias_column": "Biais",
 	"profile_score_column": "Score",
 	"profile_no_scores": "Aucun biais complété pour le moment",
 	"nav_profile": "Profil",

--- a/src/components/interactive/ProfilePage.svelte
+++ b/src/components/interactive/ProfilePage.svelte
@@ -3,6 +3,7 @@ import type { ProfilePageLabels } from "@/lib/labels";
 import { userScoresResponseSchema } from "@/lib/schemas";
 import type { ScoreEntry } from "@/lib/types";
 import { userStore } from "@/lib/userStore.svelte";
+import { profile_progression_biases } from "@/paraglide/messages";
 import PseudoEditor from "./PseudoEditor.svelte";
 import RecoveryCodeSection from "./RecoveryCodeSection.svelte";
 import RecoveryForm from "./RecoveryForm.svelte";
@@ -10,10 +11,12 @@ import ScoresList from "./ScoresList.svelte";
 
 interface Props {
 	totalBiasCount: number;
+	/** Map bias slug → { title, href } for displaying translated titles and links. */
+	biasMap: Record<string, { title: string; href: string }>;
 	labels: ProfilePageLabels;
 }
 
-let { totalBiasCount, labels }: Props = $props();
+let { totalBiasCount, biasMap, labels }: Props = $props();
 
 let scores = $state<ScoreEntry[]>([]);
 let totalScore = $state(0);
@@ -82,15 +85,17 @@ const progressPercent = $derived(
 				></div>
 			</div>
 			<p class="text-sm text-text-secondary">
-				{labels.progressionBiases(scores.length, totalBiasCount)}
+				{profile_progression_biases({ count: scores.length, total: totalBiasCount })}
 			</p>
 			<p class="mt-1 text-sm font-medium">{labels.totalScore} : {totalScore}</p>
 		</div>
 
 		<ScoresList
 			{scores}
+			{biasMap}
 			labels={{
 				title: labels.completedBiases,
+				biasColumn: labels.biasColumn,
 				scoreColumn: labels.scoreColumn,
 				noScores: labels.noScores,
 			}}

--- a/src/components/interactive/ScoresList.svelte
+++ b/src/components/interactive/ScoresList.svelte
@@ -3,14 +3,17 @@ import type { ScoreEntry } from "@/lib/types";
 
 interface Props {
 	scores: ScoreEntry[];
+	/** Map bias slug → { title, href } for translated names and links. */
+	biasMap: Record<string, { title: string; href: string }>;
 	labels: {
 		title: string;
+		biasColumn: string;
 		scoreColumn: string;
 		noScores: string;
 	};
 }
 
-let { scores, labels }: Props = $props();
+let { scores, biasMap, labels }: Props = $props();
 </script>
 
 <div>
@@ -21,14 +24,23 @@ let { scores, labels }: Props = $props();
 		<table class="w-full text-left">
 			<thead>
 				<tr class="border-b border-border text-sm text-text-secondary">
-					<th class="px-4 py-2 font-medium">Bias</th>
+					<th class="px-4 py-2 font-medium">{labels.biasColumn}</th>
 					<th class="px-4 py-2 text-right font-medium">{labels.scoreColumn}</th>
 				</tr>
 			</thead>
 			<tbody>
 				{#each scores as score}
+					{@const bias = biasMap[score.bias_slug]}
 					<tr class="border-b border-border/50">
-						<td class="px-4 py-2 font-medium">{score.bias_slug}</td>
+						<td class="px-4 py-2 font-medium">
+							{#if bias}
+								<a href={bias.href} class="no-underline hover:text-accent hover:underline">
+									{bias.title}
+								</a>
+							{:else}
+								{score.bias_slug}
+							{/if}
+						</td>
 						<td class="px-4 py-2 text-right font-semibold text-accent">
 							{score.total_score} / {1 + score.quiz_total}
 						</td>

--- a/src/lib/biases.ts
+++ b/src/lib/biases.ts
@@ -1,5 +1,6 @@
 import { getCollection } from "astro:content";
 import type { Locale } from "@/i18n/i18n";
+import { m } from "@/paraglide/messages";
 
 /** Returns all bias entries for a given locale, filtered by filePath convention (`{locale}.md`). */
 export const getBiasesForLocale = async (locale: Locale) => {
@@ -8,4 +9,15 @@ export const getBiasesForLocale = async (locale: Locale) => {
 		all: allBiases,
 		localized: allBiases.filter((bias) => bias.filePath?.endsWith(`${locale}.md`)),
 	};
+};
+
+/** Builds a slug → { title, href } map for linking biases (e.g. in profile scores). */
+export const buildBiasMap = async (locale: Locale) => {
+	const { localized } = await getBiasesForLocale(locale);
+	return Object.fromEntries(
+		localized.map((b) => [
+			b.data.slug,
+			{ title: b.data.title, href: `/${locale}/${m.slug_bias()}/${b.data.slug}` },
+		]),
+	);
 };

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -65,9 +65,9 @@ export interface ProfilePageLabels {
 	copy: string;
 	copied: string;
 	progression: string;
-	progressionBiases: (count: number, total: number) => string;
 	totalScore: string;
 	completedBiases: string;
+	biasColumn: string;
 	scoreColumn: string;
 	noScores: string;
 	recoveryForm: RecoveryFormLabels;
@@ -115,9 +115,9 @@ export const getProfileLabels = (locale: Locale): ProfilePageLabels => ({
 	copy: m.user_recovery_copy({}, { locale }),
 	copied: m.recovery_modal_copied({}, { locale }),
 	progression: m.profile_progression({}, { locale }),
-	progressionBiases: (count, total) => m.profile_progression_biases({ count, total }, { locale }),
 	totalScore: m.profile_total_score({}, { locale }),
 	completedBiases: m.profile_completed_biases({}, { locale }),
+	biasColumn: m.profile_bias_column({}, { locale }),
 	scoreColumn: m.profile_score_column({}, { locale }),
 	noScores: m.profile_no_scores({}, { locale }),
 	recoveryForm: {

--- a/src/pages/[lang]/profil.astro
+++ b/src/pages/[lang]/profil.astro
@@ -2,13 +2,14 @@
 import ProfilePage from "@/components/interactive/ProfilePage.svelte";
 import { buildAltLangHrefs } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
-import { getBiasesForLocale } from "@/lib/biases";
+import { buildBiasMap, getBiasesForLocale } from "@/lib/biases";
 import { getProfileLabels } from "@/lib/labels";
 import { m } from "@/paraglide/messages";
 
 const { locale } = Astro.locals;
 
 const { localized: biases } = await getBiasesForLocale(locale);
+const biasMap = await buildBiasMap(locale);
 const title = `${m.profile_title()} — ${m.site_title()}`;
 
 Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "profile");
@@ -17,6 +18,7 @@ Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "profile");
 <BaseLayout title={title} description={m.site_description()} lang={locale}>
 	<ProfilePage
 		totalBiasCount={biases.length}
+		{biasMap}
 		labels={getProfileLabels(locale)}
 		client:load
 	/>

--- a/src/pages/[lang]/profile.astro
+++ b/src/pages/[lang]/profile.astro
@@ -2,7 +2,7 @@
 import ProfilePage from "@/components/interactive/ProfilePage.svelte";
 import { buildAltLangHrefs } from "@/i18n/i18n";
 import BaseLayout from "@/layouts/BaseLayout.astro";
-import { getBiasesForLocale } from "@/lib/biases";
+import { buildBiasMap, getBiasesForLocale } from "@/lib/biases";
 import { getProfileLabels } from "@/lib/labels";
 import { m } from "@/paraglide/messages";
 
@@ -10,12 +10,14 @@ const { locale } = Astro.locals;
 Astro.locals.altLangHrefs = buildAltLangHrefs(locale, "profile");
 
 const { localized: biases } = await getBiasesForLocale(locale);
+const biasMap = await buildBiasMap(locale);
 const title = `${m.profile_title()} — ${m.site_title()}`;
 ---
 
 <BaseLayout title={title} description={m.site_description()} lang={locale}>
 	<ProfilePage
 		totalBiasCount={biases.length}
+		{biasMap}
 		labels={getProfileLabels(locale)}
 		client:load
 	/>


### PR DESCRIPTION
## Summary

Completed biases in the profile page now show translated titles instead of raw slugs, and are clickable links to their bias page.

- Server-side `biasMap` (slug → { title, href }) passed to ProfilePage
- ScoresList renders translated titles with links, fallback to raw slug
- Table header "Bias" translated via new `profile_bias_column` i18n key

## Test plan

- [ ] Complete a bias quiz, go to profile — bias name shows translated title
- [ ] Click on a completed bias — navigates to the bias page
- [ ] Check in both FR and EN — titles and links are locale-correct
- [ ] If a slug has no matching bias (edge case) — displays raw slug without link